### PR TITLE
require scipy>=0.14

### DIFF
--- a/flavio/statistics/probability.py
+++ b/flavio/statistics/probability.py
@@ -96,7 +96,7 @@ class MultivariateNormalDistribution(ProbabilityDistribution):
       return np.random.multivariate_normal(self.central_value, self.covariance, size)
 
    def logpdf(self, x):
-       return scipy.stats.multivariate_normal.logpdf(x, self.central_value, self.covariance, allow_singular=True)
+       return scipy.stats.multivariate_normal.logpdf(x, self.central_value, self.covariance)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='flavio',
                 'physics/data/qcdf_interpolate/*',
                 ]
       },
-      install_requires=['numpy', 'scipy', 'setuptools>=3.3', 'pyyaml', 'mpmath'],
+      install_requires=['numpy', 'scipy>=0.15', 'setuptools>=3.3', 'pyyaml', 'mpmath'],
       extras_require={
             'testing': ['nose'],
             'plotting': ['matplotlib'],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='flavio',
                 'physics/data/qcdf_interpolate/*',
                 ]
       },
-      install_requires=['numpy', 'scipy>=0.15', 'setuptools>=3.3', 'pyyaml', 'mpmath'],
+      install_requires=['numpy', 'scipy>=0.14', 'setuptools>=3.3', 'pyyaml', 'mpmath'],
       extras_require={
             'testing': ['nose'],
             'plotting': ['matplotlib'],


### PR DESCRIPTION
flavio uses the `allow_singular` argument of `scipy.stats.multivariate_normal` which is newly introduced in scipy version 0.15.