### PR TITLE
avoid some interpolation artifacts in contour plots

### DIFF
--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -542,6 +542,7 @@ def contour(x, y, z, levels,
     """
     if interpolation_factor > 1:
         if interpolation_order > 1:
+            # cut off large z values to avoid interpolation artifacts
             z_max = np.max(levels)*2.
             z[z > z_max] = z_max
         x = scipy.ndimage.zoom(x, zoom=interpolation_factor, order=1)

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -543,7 +543,7 @@ def contour(x, y, z, levels,
     if interpolation_factor > 1:
         if interpolation_order > 1:
             z_max = np.max(levels)*2.
-            z[np.nonzero(z > z_max)] = z_max
+            z[z > z_max] = z_max
         x = scipy.ndimage.zoom(x, zoom=interpolation_factor, order=1)
         y = scipy.ndimage.zoom(y, zoom=interpolation_factor, order=1)
         z = scipy.ndimage.zoom(z, zoom=interpolation_factor, order=interpolation_order)

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -541,6 +541,9 @@ def contour(x, y, z, levels,
        Ignored if `filled` is false.
     """
     if interpolation_factor > 1:
+        if interpolation_order > 1:
+            z_max = np.max(levels)*2.
+            z[np.nonzero(z > z_max)] = z_max
         x = scipy.ndimage.zoom(x, zoom=interpolation_factor, order=1)
         y = scipy.ndimage.zoom(y, zoom=interpolation_factor, order=1)
         z = scipy.ndimage.zoom(z, zoom=interpolation_factor, order=interpolation_order)


### PR DESCRIPTION
If data for which the contours are to be plotted contains very high and
sharp peaks (or other sharp transitions), ringing artifacts appear from
interpolating with splines of order 2 or higher. The ringing might even
yield negative values for purely positive data. This commit avoids these
effects by limiting the z-values to a maximum of twice the largest value
in the levels array and thus effectively cutting off high peaks.