### PR TITLE
fix bugs in FastFit with single observable and measurement

### DIFF
--- a/flavio/statistics/fits.py
+++ b/flavio/statistics/fits.py
@@ -509,7 +509,7 @@ class FastFit(Fit):
             covariances.append(covariance)
         # if there is only a single measuement
         if len(means) == 1:
-            return means[0], covariances[0]
+            return means[0][0], covariances[0]
         # if there are severeal measurements, perform a weighted average
         else:
             # covariances: [Sigma_1, Sigma_2, ...]
@@ -604,7 +604,10 @@ class FastFit(Fit):
             "Covariance matrix does not contain all necessary entries"
         assert len(permutation) == len(self.observables), \
             "Covariance matrix does not contain all necessary entries"
-        self._sm_covariance = d['covariance'][permutation][:,permutation]
+        if len(permutation) == 1:
+            self._sm_covariance = d['covariance']
+        else:
+            self._sm_covariance = d['covariance'][permutation][:,permutation]
 
     def make_measurement(self, N=100, Nexp=5000, threads=1, force=False):
         """Initialize the fit by producing a pseudo-measurement containing both

--- a/flavio/statistics/test_fits.py
+++ b/flavio/statistics/test_fits.py
@@ -124,21 +124,25 @@ class TestClasses(unittest.TestCase):
         m2 = Measurement( 'measurement 2 of test_obs 1 and test_obs 2' )
         m1.add_constraint(['test_obs 1'], d1)
         m2.add_constraint(['test_obs 1', 'test_obs 2'], d2)
-        fit = FastFit('fastfit_test_1', flavio.default_parameters, ['m_b'],  [], ['test_obs 1', 'test_obs 2'])
-        fit.make_measurement()
-        cov_before = fit._sm_covariance
-        filename = os.path.join(tempfile.gettempdir(), 'tmp-no-p')
-        fit.save_sm_covariance(filename)
-        fit.load_sm_covariance(filename)
-        cov_after = fit._sm_covariance
-        npt.assert_array_equal(cov_before, cov_after)
-        os.remove(filename)
-        filename = os.path.join(tempfile.gettempdir(), 'tmp.p')
-        fit.save_sm_covariance(filename)
-        fit.load_sm_covariance(filename)
-        cov_after = fit._sm_covariance
-        npt.assert_array_equal(cov_before, cov_after)
-        os.remove(filename)
+        fit2 = FastFit('fastfit_test_2', flavio.default_parameters, ['m_b'],  [], ['test_obs 1', 'test_obs 2'])
+        # fit with only a single observable and measurement
+        fit1 = FastFit('fastfit_test_1', flavio.default_parameters, ['m_b'],  [], ['test_obs 2',])
+        for fit in (fit2, fit1):
+            fit.make_measurement()
+            cov_before = fit._sm_covariance
+            filename = os.path.join(tempfile.gettempdir(), 'tmp-no-p')
+            fit.save_sm_covariance(filename)
+            fit.load_sm_covariance(filename)
+            cov_after = fit._sm_covariance
+            npt.assert_array_equal(cov_before, cov_after)
+            os.remove(filename)
+            filename = os.path.join(tempfile.gettempdir(), 'tmp.p')
+            fit.save_sm_covariance(filename)
+            fit.load_sm_covariance(filename)
+            cov_after = fit._sm_covariance
+            npt.assert_array_equal(cov_before, cov_after)
+            os.remove(filename)
+        fit = fit2  # the following is only for fit2
         cov_weighted = [[0.008, 0.012],[0.012,0.0855]]
         mean_weighted = [5.8, 1.7]
         exact_log_likelihood = scipy.stats.multivariate_normal.logpdf([5.9, 2.5], mean_weighted, cov_weighted)
@@ -146,10 +150,12 @@ class TestClasses(unittest.TestCase):
         self.assertAlmostEqual(fit.best_fit()['x'], 5.9, delta=0.1)
         # removing dummy instances
         FastFit.del_instance('fastfit_test_1')
+        FastFit.del_instance('fastfit_test_2')
         Observable.del_instance('test_obs 1')
         Observable.del_instance('test_obs 2')
         Measurement.del_instance('measurement 1 of test_obs 1')
         Measurement.del_instance('measurement 2 of test_obs 1 and test_obs 2')
+
 
     def test_fastfit_covariance_sm(self):
         # This test is to assure that calling make_measurement does not


### PR DESCRIPTION
While trying to define FastFit instances using only single observable and measurements, I encountered two bugs:
- The returned mean value was a 1-dim array with one entry instead of just a number.
- Performing the permutations on the SM covariance matrix after loading it from a dictionary lead to an error since this "matrix" is just a number such that no permutations can be applied.

This PR solves those two issues.