### PR TITLE
slightly streamline wc_function_factory

### DIFF
--- a/flavio/statistics/fits.py
+++ b/flavio/statistics/fits.py
@@ -73,11 +73,11 @@ def wc_function_factory(d):
     return {{{}}}""".format(', '.join(d['args']), ', '.join(["'{}': {}".format(k, v) for k, v in d['return'].items()]))
     namespace = OrderedDict()
     exec(s, globals(), namespace)  # execute string in empty namespace
-    namespace.pop('__builtins__', None)  # remove builtins key if exists
     if not namespace:
+        warnings.warn("Function dictionary provided but no function found.")
         return None
     f = namespace[list(namespace.keys())[-1]]  # assume the last variable is the function
-    if not hasattr(f, '__call__'):
+    if not callable(f):
         raise ValueError("Function code not understood")
     return f
 


### PR DESCRIPTION
@DavidMStraub In my comment https://github.com/flav-io/flavio/pull/52#issuecomment-411542206, I wrote that the `namespace` dictionary would contain a `'__builtins__'` key. However, this is only true if one uses
```python
exec(s, namespace)
```
which is equivalent to
```python
exec(s, namespace, namespace)
```
and sets both the global and the local namespace to `namespace`.
I later also realized that only the local namespace should be set to `namespace` and the global one to `globals()` like you finally did using
```python
exec(s, globals(), namespace)
```
In this case, only `globals()` will contain `'__builtins__'` and there should be no need to try removing it from `namespace`.

I've added a warning in the case where no function is found (e.g. when one uses a lambda function and forgets to assign it to a name).

I also changed `hasattr(f, '__call__')` to `callable(f)` (see e.g. the discussion here: https://stackoverflow.com/questions/16388059/using-callablex-vs-hasattrx-call)

By the way, great idea to use an OrderedDict and use the last variable as the `fit_wc_function`!