### PR TITLE
fix loading of fit_wc_function code

### DIFF
--- a/flavio/statistics/fits.py
+++ b/flavio/statistics/fits.py
@@ -217,13 +217,20 @@ class Fit(flavio.NamedInstanceClass):
         """Load the fit definition from a YAML string or stream."""
         kwargs = cls._input_schema(flavio.io.yaml.load_include(f))
         if 'fit_wc_function' in kwargs:
+            # Copy string defining the fit_wc_function to local variable.
             fit_wc_function_string = kwargs['fit_wc_function'].copy()
+            # Replace kwargs['fit_wc_function'] by actual function.
             kwargs['fit_wc_function'] = wc_function_factory(fit_wc_function_string)
         else:
             fit_wc_function_string = None
         fit = cls(**kwargs)
         if fit_wc_function_string is not None:
+            # Save string defining the fit_wc_function as private attribute of fit.
             fit._fit_wc_function_string = fit_wc_function_string
+            # Save the fit_wc_function associated to fit_wc_function_string as
+            # private method of fit. This allows comparing it with the public
+            # method fit.fit_wc_function and to infer if fit.fit_wc_function
+            # has been changed since initialization
             fit._fit_wc_function_orig = kwargs['fit_wc_function']
         return fit
 
@@ -234,10 +241,15 @@ class Fit(flavio.NamedInstanceClass):
         in the `par_obj` argument or `fit_wc_priors`.
         """
         d = self.__dict__.copy()
+        # Dump string defining the fit_wc_function if it exists and if
+        # fit_wc_function has not been changed since intialization, i.e. if it
+        # is identical to the original function _fit_wc_function_orig that has
+        # been generated from the string
         if ('_fit_wc_function_string' in d
         and '_fit_wc_function_orig' in d
         and d['fit_wc_function'] ==  d['_fit_wc_function_orig']):
             d['fit_wc_function'] = d['_fit_wc_function_string']
+        # Otherwise, dump the pickled fit_wc_function
         elif d['fit_wc_function'] is not None:
             d['fit_wc_function'] = fencode(d['fit_wc_function'])
         d = self._output_schema(d)

--- a/flavio/statistics/test_fits.py
+++ b/flavio/statistics/test_fits.py
@@ -321,10 +321,31 @@ fit_wc_function:
         fit = FastFit.load(s)
         self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
         self.assertDictEqual(fit.fit_wc_function(1, 2), {'C9_bsmumu': 10, 'C10_bsmumu': 60})
+        fit = FastFit.load(r"""
+name: my test fit 5
+observables:
+    - [<dBR/dq2>(B0->K*mumu), 15, 19]
+input_scale: 1000
+fit_wc_eft: SMEFT
+fit_wc_basis: Warsaw
+fit_wc_function:
+  code: |
+    from math import sqrt
+    def f(C9, C10):
+      return {'C9_bsmumu': 10 * sqrt(C9),
+              'C10_bsmumu': 30 * C10}
+  """)
+        self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
+        self.assertDictEqual(fit.fit_wc_function(4, 2), {'C9_bsmumu': 20.0, 'C10_bsmumu': 60})
+        # dump and load back again
+        s = fit.dump().replace('my test fit 5', 'my test fit 5.1')
+        fit = FastFit.load(s)
+        self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
+        self.assertDictEqual(fit.fit_wc_function(4, 2), {'C9_bsmumu': 20., 'C10_bsmumu': 60})
         def myf(C9, C10):
           return {'C9_bsmumu': 10 * C9,
                   'C10_bsmumu': 30 * C10}
-        fit = FastFit('my test fit 5',
+        fit = FastFit('my test fit 6',
                       observables=[('<dBR/dq2>(B0->K*mumu)', 15, 19)],
                       input_scale=1000,
                       fit_wc_eft='SMEFT',
@@ -334,3 +355,30 @@ fit_wc_function:
         fit = FastFit.load(s)
         self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
         self.assertDictEqual(fit.fit_wc_function(1, 2), {'C9_bsmumu': 10, 'C10_bsmumu': 60})
+        from math import floor
+        def myf(C9, C10):
+          return {'C9_bsmumu': floor(C9),
+                  'C10_bsmumu': 30 * C10}
+        fit = FastFit('my test fit 7',
+                      observables=[('<dBR/dq2>(B0->K*mumu)', 15, 19)],
+                      input_scale=1000,
+                      fit_wc_eft='SMEFT',
+                      fit_wc_basis='Warsaw',
+                      fit_wc_function=myf)
+        s = fit.dump()
+        fit = FastFit.load(s)
+        self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
+        self.assertDictEqual(fit.fit_wc_function(2.123, 2), {'C9_bsmumu': 2, 'C10_bsmumu': 60})
+        def myf(C9, C10):
+          return {'C9_bsmumu': abs(C9),
+                  'C10_bsmumu': 30 * C10}
+        fit = FastFit('my test fit 8',
+                      observables=[('<dBR/dq2>(B0->K*mumu)', 15, 19)],
+                      input_scale=1000,
+                      fit_wc_eft='SMEFT',
+                      fit_wc_basis='Warsaw',
+                      fit_wc_function=myf)
+        s = fit.dump()
+        fit = FastFit.load(s)
+        self.assertTupleEqual(fit.fit_wc_names, ('C9', 'C10'))
+        self.assertDictEqual(fit.fit_wc_function(-1, 2), {'C9_bsmumu': 1, 'C10_bsmumu': 60})


### PR DESCRIPTION
@DavidMStraub I think the solution to use `OrderedDict` introduced in commit b73f9493abdd5d58265db09ff91fdff6eae3e46e is extremely useful. In particular, it allows to load a YAML string where the `fit_wc_function` requires the import of an external module or function like e.g. the function `sqrt()` as in the following example:
```YAML
name: my test fit with external module
observables:
    - [<dBR/dq2>(B0->K*mumu), 15, 19]
input_scale: 1000
fit_wc_eft: SMEFT
fit_wc_basis: Warsaw
fit_wc_function:
  code: |
    from math import sqrt
    def f(C9, C10):
      return {'C9_bsmumu': 10 * sqrt(C9),
              'C10_bsmumu': 30 * C10}
```
Unfortunately, due to the changes in commit 4007b8cd3d92940ea328382815108895e7df40e0, this doesn't work anymore.

Before this commit, `exec` was called as
```python
exec(s, namespace)
```
such that the global and the local namespaces for the executed code have been identical and given by the OrderedDict `namespace`.

After the commit, the `exec` call has been changed to
```python
exec(s, globals(), namespace)
```
Now, this has the problem that global and local namespaces are not identical anymore and using the above example YAML string, the function `f` would not be able to find the function `sqrt` in its global namespace (which is now set to `globals()`), because `sqrt` is only defined in the local namespace `namespace`. So loading of the above YAML string leads to a `NameError` after commit 4007b8cd3d92940ea328382815108895e7df40e0 while loading the same YAML perfectly worked before.

But what is the reason to change `exec(s, namespace)` to `exec(s, globals(), namespace)`?
The former solution actually lead to the following problem: If a `fit_wc_function` defined by `exec(s, namespace)` contains a call to any function in the `globals()` namespace, like e.g. `abs()`, then pickling `fit_wc_function` and unpickling it again leads to an unpickled `fit_wc_function` that is not able to find `abs()` anymore. Using the global namespace `globals()` in the `exec` call is an apparent solution. By using `exec(s, globals(), namespace)`, the `fit_wc_function` can still find `abs()` after pickling and unpickling.

However, this is not a real solution since it only solves the problem for functions in the `globals()` namespace. At the same time, it introduces the problem described above: any function imported to the local namespace `namespace`, like `sqrt()` in the example above, leads to a `NameError` when loading the YAML string.

So I think one has to use
```python
exec(s, namespace)
```
This then prevents the functions to be properly pickled and unpickled, which is in this case obviously not very well supported by `dill`.

To solve all those issues, I suggest to simply not pickle any functions defined by `exec` in the `wc_function_factory`, but to save their defining YAML instead as done before commit 4007b8cd3d92940ea328382815108895e7df40e0, with the modification proposed in comment https://github.com/flav-io/flavio/pull/50#issuecomment-411678529. This is done in the present PR.