### PR TITLE
add observables and measurement for combined (l1+ l2-, l2+ l1-) LFV BR(B->Ml1l2,l2l1)

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -4764,3 +4764,10 @@ BaBar B->Kll LFV 2016:
     BR(B0->K*mue): -7 + 22 - 14 ± 7 e-8
     BR(B+->K*emu): 9+ 65 - 44 ± 22 e-8
     BR(B+->K*mue): -32+ 63 - 38 ± 15 e-8
+
+BaBar B->pill LFV 2007:
+  experiment: BaBar
+  inspire: Aubert:2007mm
+  values:
+    BR(B+->piemu,mue): < 1.7e-7 @ 90% CL
+    BR(B0->piemu,mue): < 1.4e-7 @ 90% CL

--- a/flavio/physics/bdecays/bpll.py
+++ b/flavio/physics/bdecays/bpll.py
@@ -236,7 +236,8 @@ _hadr_lfv = {
 _tex_lfv = {'emu': r'e^+\mu^-', 'mue': r'\mu^+e^-',
     'taue': r'\tau^+e^-', 'etau': r'e^+\tau^-',
     'taumu': r'\tau^+\mu^-', 'mutau': r'\mu^+\tau^-',
-    'emu,mue': r'e^\pm\mu^\mp'}
+    'emu,mue': r'e^\pm\mu^\mp', 'etau,taue': r'e^\pm\tau^\mp',
+    'mutau,taumu': r'\mu^\pm\tau^\mp'}
 
 for l in ['e', 'mu', 'tau']:
     for M in _hadr.keys():
@@ -310,14 +311,11 @@ def _define_obs_B_Mll(M, ll):
     _obs.add_taxonomy(_process_taxonomy)
     return _obs_name
 
-for ll in [('e','mu'), ('mu','e'), ('e','tau'), ('tau','e'), ('mu','tau'), ('tau','mu')]:
-    for M in _hadr_lfv:
+for M in _hadr_lfv:
+    for ll in [('e','mu'), ('mu','e'), ('e','tau'), ('tau','e'), ('mu','tau'), ('tau','mu')]:
         _obs_name = _define_obs_B_Mll(M, ll)
         Prediction(_obs_name, bpll_dbrdq2_tot_func(_hadr_lfv[M]['B'], _hadr_lfv[M]['P'], ll[0], ll[1]))
-
-# Combined emu+mue lepton flavour violating decays
-_obs_name = _define_obs_B_Mll('B+->pi', ('emu,mue',))
-Prediction(_obs_name, bpll_dbrdq2_tot_lfv_comb_func('B+', 'pi+', 'e', 'mu'))
-
-_obs_name = _define_obs_B_Mll('B0->pi', ('emu,mue',))
-Prediction(_obs_name, bpll_dbrdq2_tot_lfv_comb_func('B0', 'pi0', 'e', 'mu'))
+    for ll in [('e','mu'), ('e','tau'), ('mu','tau')]:
+        # Combined l1+ l2- + l2+ l1- lepton flavour violating decays
+        _obs_name = _define_obs_B_Mll(M, ('{0}{1},{1}{0}'.format(*ll),))
+        Prediction(_obs_name, bpll_dbrdq2_tot_lfv_comb_func(_hadr_lfv[M]['B'], _hadr_lfv[M]['P'], ll[0], ll[1]))

--- a/flavio/physics/bdecays/bpll.py
+++ b/flavio/physics/bdecays/bpll.py
@@ -223,7 +223,7 @@ _hadr_lfv = {
 _tex_lfv = {'emu': r'e^+\mu^-', 'mue': r'\mu^+e^-',
     'taue': r'\tau^+e^-', 'etau': r'e^+\tau^-',
     'taumu': r'\tau^+\mu^-', 'mutau': r'\mu^+\tau^-',
-    'emu+mue': r'e^\pm\mu^\mp'}
+    'emu,mue': r'e^\pm\mu^\mp'}
 
 for l in ['e', 'mu', 'tau']:
     for M in _hadr.keys():
@@ -315,5 +315,5 @@ def _B_pi_emu_mue_fct(wc_obj, par):
         + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, 'B+', 'pi+', 'e', 'mu')
         + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, 'B+', 'pi+', 'mu', 'e')
     )*(q2max-q2min)
-_obs_name = _define_obs_B_Mll('B+->pi', ('emu+mue',))
+_obs_name = _define_obs_B_Mll('B+->pi', ('emu,mue',))
 Prediction(_obs_name, _B_pi_emu_mue_fct)

--- a/flavio/physics/bdecays/bpll.py
+++ b/flavio/physics/bdecays/bpll.py
@@ -160,6 +160,19 @@ def bpll_dbrdq2_tot_func(B, P, l1, l2):
         return bpll_dbrdq2_int(q2min, q2max, wc_obj, par, B, P, l1, l2)*(q2max-q2min)
     return fct
 
+def bpll_dbrdq2_tot_lfv_comb_func(B, P, l1, l2):
+    def fct(wc_obj, par):
+        mB = par['m_'+B]
+        mP = par['m_'+P]
+        ml1 = par['m_'+l1]
+        ml2 = par['m_'+l2]
+        q2max = (mB-mP)**2
+        q2min = (ml1+ml2)**2
+        return (
+            + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, B, P, l1, l2)
+            + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, B, P, l2, l1)
+        )*(q2max-q2min)
+    return fct
 
 def bpll_dbrdq2_func(B, P, l1, l2):
     def fct(wc_obj, par, q2):
@@ -302,18 +315,9 @@ for ll in [('e','mu'), ('mu','e'), ('e','tau'), ('tau','e'), ('mu','tau'), ('tau
         _obs_name = _define_obs_B_Mll(M, ll)
         Prediction(_obs_name, bpll_dbrdq2_tot_func(_hadr_lfv[M]['B'], _hadr_lfv[M]['P'], ll[0], ll[1]))
 
-# Combined emu+mue lepton flavour violating decay B->pi(emu+mue) (hep-ex/0703018)
-# Br(B->pil+l-) = Br(B+->pi+l+l-) = 2 tau_B+/tau_B0 Br(B0->pi0l+l-)
-def _B_pi_emu_mue_fct(wc_obj, par):
-    mB = par['m_B+']
-    mP = par['m_pi+']
-    me = par['m_e']
-    mmu = par['m_mu']
-    q2max = (mB-mP)**2
-    q2min = (me+mmu)**2
-    return (
-        + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, 'B+', 'pi+', 'e', 'mu')
-        + bpll_dbrdq2_int(q2min, q2max, wc_obj, par, 'B+', 'pi+', 'mu', 'e')
-    )*(q2max-q2min)
+# Combined emu+mue lepton flavour violating decays
 _obs_name = _define_obs_B_Mll('B+->pi', ('emu,mue',))
-Prediction(_obs_name, _B_pi_emu_mue_fct)
+Prediction(_obs_name, bpll_dbrdq2_tot_lfv_comb_func('B+', 'pi+', 'e', 'mu'))
+
+_obs_name = _define_obs_B_Mll('B0->pi', ('emu,mue',))
+Prediction(_obs_name, bpll_dbrdq2_tot_lfv_comb_func('B0', 'pi0', 'e', 'mu'))


### PR DESCRIPTION
@DavidMStraub, this PR defines the `Observable` instance for the combined emu+mue LFV BR(B->pi(emu+mue)) as used in https://arxiv.org/pdf/hep-ex/0703018.pdf.
To this end, I have put everything used to define the LFV M->Pll `Observable` instances into the function `_define_obs_B_Mll` and removed the currently unnecessary loop `for br in ['BR',]:`. I hope this fine.

Please double-check that my assumption
BR(B->pi(emu+mue)) = BR(B+->pi+ emu) + BR(B+->pi+ mue)
is correct.

Note that like in the last two commits in master, the test introduced in 4056db5df4387a3aea32adbe833a369714ca2604 is failing (`KeyError: 'test_obs 1'`).