### PR TITLE
Tau->vl

### DIFF
--- a/flavio/physics/taudecays/common.py
+++ b/flavio/physics/taudecays/common.py
@@ -13,10 +13,10 @@ def GammaFvf(M, mv, mf, gL, gR, gTL=0, gtTL=0, gTR=0, gtTR=0):
                 * (2*(mf**2 - M**2)**2 /mv**2 - mf**2 - M**2 - mv**2)
                 - 12 * mf * M * ( (gTL-gtTL).real * (gTR+gtTR).real
                                 + (gTL-gtTL).imag * (gTR+gtTR).imag ) )
-        I = ( 3*M * (mv**2 + mf**2 - M**2)
+        I = ( 3*M * (M**2 - mf**2 - mv**2)
                 *( gL.real*(gTR+gtTR).real + gR.real*(gTL-gtTL).real
                  + gL.imag*(gTR+gtTR).imag + gR.imag*(gTL-gtTL).imag)
-            + 3*mf * (mv**2 + M**2 - mf**2)
+            + 3*mf * (mf**2 - M**2 - mv**2)
                 *( gL.real*(gTL-gtTL).real + gR.real*(gTR+gtTR).real
                  + gL.imag*(gTL-gtTL).imag + gR.imag*(gTR+gtTR).imag) )
         amp2 = amp2_V + amp2_T + I

--- a/flavio/physics/taudecays/common.py
+++ b/flavio/physics/taudecays/common.py
@@ -7,18 +7,15 @@ def GammaFvf(M, mv, mf, gL, gR, gTL=0, gtTL=0, gTR=0, gtTR=0):
     """Generic decay width of a fermion to a vector boson and a fermion."""
     amp2_V = ((abs(gL)**2 + abs(gR)**2)
             * ((mf**2 - M**2)**2 /mv**2 + mf**2 + M**2 - 2. *mv**2)
-            - 12 * mf * M * (gL.real * gR.real + gL.imag * gR.imag))/2.
+            - 12 * mf * M * ( gR*gL.conjugate() ).real )/2.
     if any([gTL,gtTL,gTR,gtTR]):
         amp2_T = mv**2/2*( (abs(gTL-gtTL)**2 + abs(gTR+gtTR)**2)
                 * (2*(mf**2 - M**2)**2 /mv**2 - mf**2 - M**2 - mv**2)
-                - 12 * mf * M * ( (gTL-gtTL).real * (gTR+gtTR).real
-                                + (gTL-gtTL).imag * (gTR+gtTR).imag ) )
+                - 12 * mf * M * ( (gTR+gtTR)*(gTL-gtTL).conjugate() ).real )
         I = ( 3*M * (M**2 - mf**2 - mv**2)
-                *( gL.real*(gTR+gtTR).real + gR.real*(gTL-gtTL).real
-                 + gL.imag*(gTR+gtTR).imag + gR.imag*(gTL-gtTL).imag)
+            *( gL*(gTR+gtTR).conjugate() + gR*(gTL-gtTL).conjugate() ).real
             + 3*mf * (mf**2 - M**2 - mv**2)
-                *( gL.real*(gTL-gtTL).real + gR.real*(gTR+gtTR).real
-                 + gL.imag*(gTL-gtTL).imag + gR.imag*(gTR+gtTR).imag) )
+            *( gR*(gTR+gtTR).conjugate() + gL*(gTL-gtTL).conjugate() ).real )
         amp2 = amp2_V + amp2_T + I
     else:
         amp2 = amp2_V

--- a/flavio/physics/taudecays/common.py
+++ b/flavio/physics/taudecays/common.py
@@ -3,11 +3,25 @@
 from flavio.physics.common import lambda_K
 from math import sqrt, pi
 
-def GammaFvf(M, mv, mf, gL, gR):
+def GammaFvf(M, mv, mf, gL, gR, gTL=0, gtTL=0, gTR=0, gtTR=0):
     """Generic decay width of a fermion to a vector boson and a fermion."""
-    amp2 = ((abs(gL)**2 + abs(gR)**2)
+    amp2_V = ((abs(gL)**2 + abs(gR)**2)
             * ((mf**2 - M**2)**2 /mv**2 + mf**2 + M**2 - 2. *mv**2)
             - 12 * mf * M * (gL.real * gR.real + gL.imag * gR.imag))/2.
+    if any([gTL,gtTL,gTR,gtTR]):
+        amp2_T = mv**2/2*( (abs(gTL-gtTL)**2 + abs(gTR+gtTR)**2)
+                * (2*(mf**2 - M**2)**2 /mv**2 - mf**2 - M**2 - mv**2)
+                - 12 * mf * M * ( (gTL-gtTL).real * (gTR+gtTR).real
+                                + (gTL-gtTL).imag * (gTR+gtTR).imag ) )
+        I = ( 3*M * (mv**2 + mf**2 - M**2)
+                *( gL.real*(gTR+gtTR).real + gR.real*(gTL-gtTL).real
+                 + gL.imag*(gTR+gtTR).imag + gR.imag*(gTL-gtTL).imag)
+            + 3*mf * (mv**2 + M**2 - mf**2)
+                *( gL.real*(gTL-gtTL).real + gR.real*(gTR+gtTR).real
+                 + gL.imag*(gTL-gtTL).imag + gR.imag*(gTR+gtTR).imag) )
+        amp2 = amp2_V + amp2_T + I
+    else:
+        amp2 = amp2_V
     return Gamma(amp2, M, mf, mv)
 
 def GammaFsf(M, ms, mf, gL, gR):

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -53,44 +53,7 @@ def br_tauvl(wc_obj, par, V, lep):
             * common.GammaFvf(mtau, mV, ml, gL, gR, gTL, gtTL, gTR, gtTR) )
 
 
-def br_taurhol(wc_obj, par, lep):
-    r"""Branching ratio of $\tau^+\to rho^0\ell^+$."""
-    V = 'rho0'
-    scale = flavio.config['renormalization scale']['taudecays']
-    sec = wcxf_sector_names['tau', lep]
-    wc = wc_obj.get_wc(sec, scale, par, nf_out=4)
-    alpha = flavio.physics.running.running.get_alpha_e(par, scale, nf_out=3)
-    e = sqrt(4 * pi * alpha)
-    mV = par['m_' + V]
-    mtau = par['m_tau']
-    x = mV**2 / mtau**2
-    # add factor 2 in pre_wc_1 to account for definition of sigma_munu
-    pre_wc_1 = 1 / e / mtau *2
-    e2DLg = e**2 * pre_wc_1 * wc['Cgamma_tau{}'.format(lep)]
-    e2DRg = e**2 * pre_wc_1 * wc['Cgamma_{}tau'.format(lep)].conjugate()
-    F = {}
-    for q in 'ud':
-        F['LL' + q] = wc['CVLL_tau{}{}'.format(lep, 2 * q   )]
-        F['RR' + q] = wc['CVRR_tau{}{}'.format(lep, 2 * q)]
-        F['LR' + q] = wc['CVLR_tau{}{}'.format(lep, 2 * q)]
-        F['RL' + q] = wc['CVLR_{}tau{}'.format(2 * q, lep)]
-    if V == 'rho0':
-        FL = (F['LLu'] - F['LLd']) / 2 + (F['LRu'] - F['LRd']) / 2
-        FR = (F['RLu'] - F['RLd']) / 2 + (F['RRu'] - F['RRd']) / 2
-        Vud = flavio.physics.ckm.get_ckm(par)[0, 0]
-        norm = 1 / (4 * par['GF']**2 * abs(Vud)**2) * par['BR(tau->rhonu)']
-    rWC = (abs(FL)**2 + abs(FR)**2
-           - 6 / (1 + 2 * x) * (e2DLg * FL.conjugate() + e2DRg * FR.conjugate()).real
-           + (2 + x) / (x * (1 + 2 * x)) * (abs(e2DLg)**2 + abs(e2DRg)**2))
-    return norm * rWC
-
-
 # function returning function needed for prediction instance
-def br_taurhol_fct(lep):
-    def f(wc_obj, par):
-        return br_taurhol(wc_obj, par, lep)
-    return f
-
 def br_tauvl_fct(V, lep):
     def f(wc_obj, par):
         return br_tauvl(wc_obj, par, V, lep)
@@ -112,15 +75,3 @@ for V in _had:
         _obs.set_description(r"Branching ratio of $" + _process_tex + r"$")
         _obs.tex = r"$\text{BR}(" + _process_tex + r")$"
         flavio.classes.Prediction(_obs_name, br_tauvl_fct(V, l))
-
-
-# Observable and Prediction instances for tau->rhol
-for l in _lep:
-    _obs_name = "old_BR(tau->rho" + l + r")"
-    _obs = flavio.classes.Observable(_obs_name)
-    _process_tex = r"\tau^+\to \rho^0" + _lep[l] + r"^+"
-    _process_taxonomy = r'Process :: $\tau$ lepton decays :: LFV decays :: $\tau\to V\ell$ :: $' + _process_tex + r"$"
-    _obs.add_taxonomy(_process_taxonomy)
-    _obs.set_description(r"Branching ratio of $" + _process_tex + r"$")
-    _obs.tex = r"$\text{BR}(" + _process_tex + r")$"
-    flavio.classes.Prediction(_obs_name, br_taurhol_fct(l))

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -64,9 +64,11 @@ def br_taurhol(wc_obj, par, lep):
     mV = par['m_' + V]
     mtau = par['m_tau']
     x = mV**2 / mtau**2
-    pre_wc_1 = 1 / e / mtau
+    # add factor 2 in pre_wc_1 to account for definition of sigma_munu
+    pre_wc_1 = 1 / e / mtau *2
     e2DLg = e**2 * pre_wc_1 * wc['Cgamma_tau{}'.format(lep)]
-    e2DRg = e**2 * pre_wc_1 * wc['Cgamma_{}tau'.format(lep)].conjugate()
+    # add factor (-1) in e2DRg to account for adjoint F_munu
+    e2DRg = e**2 * pre_wc_1 * wc['Cgamma_{}tau'.format(lep)].conjugate() *(-1)
     F = {}
     for q in 'ud':
         F['LL' + q] = wc['CVLL_tau{}{}'.format(lep, 2 * q   )]

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -10,8 +10,9 @@ wcxf_sector_names = {('tau', 'mu'): 'mutau',
                      ('mu', 'e'): 'mue', }
 
 
-def br_tauvl(wc_obj, par, V, lep):
-    r"""Branching ratio of $\tau^+\to V^0\ell^+$."""
+def br_taurhol(wc_obj, par, lep):
+    r"""Branching ratio of $\tau^+\to rho^0\ell^+$."""
+    V = 'rho0'
     scale = flavio.config['renormalization scale']['taudecays']
     sec = wcxf_sector_names['tau', lep]
     wc = wc_obj.get_wc(sec, scale, par, nf_out=4)
@@ -41,9 +42,9 @@ def br_tauvl(wc_obj, par, V, lep):
 
 
 # function returning function needed for prediction instance
-def br_tauvl_fct(V, lep):
+def br_taurhol_fct(lep):
     def f(wc_obj, par):
-        return br_tauvl(wc_obj, par, V, lep)
+        return br_taurhol(wc_obj, par, lep)
     return f
 
 # Observable and Prediction instances
@@ -52,13 +53,13 @@ _had = {'rho0': r'\rho^0',}
 _shortname = {'rho0': 'rho',}
 _lep = {'e': ' e', 'mu': r'\mu',}
 
-for V in _had:
-    for l in _lep:
-        _obs_name = "BR(tau->" + _shortname[V] + l + r")"
-        _obs = flavio.classes.Observable(_obs_name)
-        _process_tex = r"\tau^+\to " + _had[V] + _lep[l] + r"^+"
-        _process_taxonomy = r'Process :: $\tau$ lepton decays :: LFV decays :: $\tau\to V\ell$ :: $' + _process_tex + r"$"
-        _obs.add_taxonomy(_process_taxonomy)
-        _obs.set_description(r"Branching ratio of $" + _process_tex + r"$")
-        _obs.tex = r"$\text{BR}(" + _process_tex + r")$"
-        flavio.classes.Prediction(_obs_name, br_tauvl_fct(V, l))
+# Observable and Prediction instances for tau->rhol
+for l in _lep:
+    _obs_name = "old_BR(tau->rho" + l + r")"
+    _obs = flavio.classes.Observable(_obs_name)
+    _process_tex = r"\tau^+\to \rho^0" + _lep[l] + r"^+"
+    _process_taxonomy = r'Process :: $\tau$ lepton decays :: LFV decays :: $\tau\to V\ell$ :: $' + _process_tex + r"$"
+    _obs.add_taxonomy(_process_taxonomy)
+    _obs.set_description(r"Branching ratio of $" + _process_tex + r"$")
+    _obs.tex = r"$\text{BR}(" + _process_tex + r")$"
+    flavio.classes.Prediction(_obs_name, br_taurhol_fct(l))

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -45,7 +45,7 @@ def br_tauvl(wc_obj, par, V, lep):
         KV = -1/3*e
     gL = mV*fV/2 * (g[0] + g[1])
     gR = mV*fV/2 * (g[2] + g[3])
-    gTL  =  fTV * g[4].conjugate() - 2*fV*KV/mV * Cgamma_ltau.conjugate()
+    gTL  =  fTV * g[4].conjugate() + 2*fV*KV/mV * Cgamma_ltau.conjugate()
     gtTL = -fTV * g[4].conjugate()
     gTR  =  fTV * g[5] + 2*fV*KV/mV * Cgamma_taul
     gtTR =  fTV * g[5]
@@ -67,8 +67,7 @@ def br_taurhol(wc_obj, par, lep):
     # add factor 2 in pre_wc_1 to account for definition of sigma_munu
     pre_wc_1 = 1 / e / mtau *2
     e2DLg = e**2 * pre_wc_1 * wc['Cgamma_tau{}'.format(lep)]
-    # add factor (-1) in e2DRg to account for adjoint F_munu
-    e2DRg = e**2 * pre_wc_1 * wc['Cgamma_{}tau'.format(lep)].conjugate() *(-1)
+    e2DRg = e**2 * pre_wc_1 * wc['Cgamma_{}tau'.format(lep)].conjugate()
     F = {}
     for q in 'ud':
         F['LL' + q] = wc['CVLL_tau{}{}'.format(lep, 2 * q   )]

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -1,13 +1,42 @@
 r"""Functions for $\tau\to V\ell$."""
 
 import flavio
+from flavio.physics.taudecays import common
 from math import sqrt, pi
+import numpy as np
 
 
 # names of LFV sectors in WCxf
 wcxf_sector_names = {('tau', 'mu'): 'mutau',
                      ('tau', 'e'): 'taue',
                      ('mu', 'e'): 'mue', }
+
+def get_wcs(wc, q, lep):
+        return np.array([
+            wc['CVLL_tau{}{}'.format(lep, 2 * q)],
+            wc['CVLR_tau{}{}'.format(lep, 2 * q)],
+            wc['CVLR_{}tau{}'.format(2 * q, lep)],
+            wc['CVRR_tau{}{}'.format(lep, 2 * q)],
+        ])
+
+def br_tauvl(wc_obj, par, V, lep):
+    r"""Branching ratio of $\tau^+\to V^0\ell^+$."""
+    scale = flavio.config['renormalization scale']['taudecays']
+    sec = wcxf_sector_names['tau', lep]
+    wc = wc_obj.get_wc(sec, scale, par, nf_out=4)
+    mtau = par['m_tau']
+    ml = par['m_' + lep]
+    mV = par['m_' + V]
+    fV = par['f_' + V]
+    if V == 'rho0':
+        g_u = get_wcs(wc, 'u', lep)
+        g_d = get_wcs(wc, 'd', lep)
+        g = (g_u-g_d)/sqrt(2)
+    if V == 'phi':
+        g = get_wcs(wc, 's', lep)
+    gL = mV*fV/2 * (g[0] + g[1])
+    gR = mV*fV/2 * (g[2] + g[3])
+    return par['tau_tau'] * common.GammaFvf(mtau, mV, ml, gL, gR)
 
 
 def br_taurhol(wc_obj, par, lep):
@@ -47,11 +76,28 @@ def br_taurhol_fct(lep):
         return br_taurhol(wc_obj, par, lep)
     return f
 
+def br_tauvl_fct(V, lep):
+    def f(wc_obj, par):
+        return br_tauvl(wc_obj, par, V, lep)
+    return f
+
 # Observable and Prediction instances
 
-_had = {'rho0': r'\rho^0',}
-_shortname = {'rho0': 'rho',}
+_had = {'rho0': r'\rho^0', 'phi': r'\phi'}
+_shortname = {'rho0': 'rho', 'phi': 'phi'}
 _lep = {'e': ' e', 'mu': r'\mu',}
+
+for V in _had:
+    for l in _lep:
+        _obs_name = "BR(tau->" + _shortname[V] + l + r")"
+        _obs = flavio.classes.Observable(_obs_name)
+        _process_tex = r"\tau^+\to " + _had[V] + _lep[l] + r"^+"
+        _process_taxonomy = r'Process :: $\tau$ lepton decays :: LFV decays :: $\tau\to V\ell$ :: $' + _process_tex + r"$"
+        _obs.add_taxonomy(_process_taxonomy)
+        _obs.set_description(r"Branching ratio of $" + _process_tex + r"$")
+        _obs.tex = r"$\text{BR}(" + _process_tex + r")$"
+        flavio.classes.Prediction(_obs_name, br_tauvl_fct(V, l))
+
 
 # Observable and Prediction instances for tau->rhol
 for l in _lep:

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -39,16 +39,16 @@ def br_tauvl(wc_obj, par, V, lep):
         g_u = get_wcs(wc, 'u', lep)
         g_d = get_wcs(wc, 'd', lep)
         g = (g_u-g_d)/sqrt(2)
-        KV = 1/sqrt(2)*e
+        KV = -1/sqrt(2)*e
     if V == 'phi':
         g = get_wcs(wc, 's', lep)
-        KV = -1/3*e
+        KV = 1/3*e
     gL = mV*fV/2 * (g[0] + g[1])
     gR = mV*fV/2 * (g[2] + g[3])
-    gTL  =  fTV * g[4].conjugate() + 2*fV*KV/mV * Cgamma_ltau.conjugate()
-    gtTL = -fTV * g[4].conjugate()
-    gTR  =  fTV * g[5] + 2*fV*KV/mV * Cgamma_taul
-    gtTR =  fTV * g[5]
+    gTL  = -fTV * g[4].conjugate() - 2*fV*KV/mV * Cgamma_ltau.conjugate()
+    gtTL = +fTV * g[4].conjugate()
+    gTR  = -fTV * g[5] - 2*fV*KV/mV * Cgamma_taul
+    gtTR = -fTV * g[5]
     return (par['tau_tau']
             * common.GammaFvf(mtau, mV, ml, gL, gR, gTL, gtTL, gTR, gtTR) )
 

--- a/flavio/physics/taudecays/tauvl.py
+++ b/flavio/physics/taudecays/tauvl.py
@@ -45,10 +45,10 @@ def br_tauvl(wc_obj, par, V, lep):
         KV = 1/3*e
     gL = mV*fV/2 * (g[0] + g[1])
     gR = mV*fV/2 * (g[2] + g[3])
-    gTL  = -fTV * g[4].conjugate() - 2*fV*KV/mV * Cgamma_ltau.conjugate()
-    gtTL = +fTV * g[4].conjugate()
-    gTR  = -fTV * g[5] - 2*fV*KV/mV * Cgamma_taul
-    gtTR = -fTV * g[5]
+    gTL  = +fTV * g[4].conjugate() + 2*fV*KV/mV * Cgamma_ltau.conjugate()
+    gtTL = -fTV * g[4].conjugate()
+    gTR  = +fTV * g[5] + 2*fV*KV/mV * Cgamma_taul
+    gtTR = +fTV * g[5]
     return (par['tau_tau']
             * common.GammaFvf(mtau, mV, ml, gL, gR, gTL, gtTL, gTR, gtTR) )
 


### PR DESCRIPTION
This PR replaces the old implementation of BR(tau->Vl) that only worked for V=rho0 with a more general one that is also applicable to V=phi.

At the moment, all contributions of operators with vector currents are taken into account as was done in the old implementation. The calculation will be extended in another PR to also consider operators with tensor currents. 

For testing and code review purposes, the old implementation is kept in the code for now and the corresponding predictions are available via the `old_BR(tau->rhomu)` and `old_BR(tau->rhoe)` observables. They should be removed before merging this PR.

Comparing the predictions of `BR(tau->rhomu)` and `old_BR(tau->rhomu)`, I found a difference of <3% for the case where the light lepton mass is set to zero (by replacing `ml` with `0` in line 39, https://github.com/flav-io/flavio/compare/master...peterstangl:tau-Vl?expand=1#diff-4512a505bf1b4ff6faba7c076aec7b12R39). This approximation was used in the old implementation.
In the case where a finite `ml` is kept, I found a difference between  `BR(tau->rhomu)` and `old_BR(tau->rhomu)` of ~7%.