### PR TITLE
Bug when loading covariance with several observables for a single observable FastFit

### DIFF
--- a/flavio/statistics/fits.py
+++ b/flavio/statistics/fits.py
@@ -680,7 +680,10 @@ class FastFit(Fit):
         assert len(permutation) == len(self.observables), \
             "Covariance matrix does not contain all necessary entries"
         if len(permutation) == 1:
-            self._sm_covariance = d['covariance']
+            if d['covariance'].shape == ():
+                self._sm_covariance = d['covariance']
+            else:
+                self._sm_covariance = d['covariance'][permutation][:,permutation][0,0]
         else:
             self._sm_covariance = d['covariance'][permutation][:,permutation]
 


### PR DESCRIPTION
Bug introduced in pull request #48 -- there is an edge case that if we using FastFit with only a single observable, but are loading a covariance with multiple observables, we get the whole covariance matrix instead of a single element.
Fix by checking the size of the covariance matrix being loaded.