### PR TITLE
use cache for predctions in likelihood

### DIFF
--- a/flavio/physics/eft.py
+++ b/flavio/physics/eft.py
@@ -131,6 +131,14 @@ class WilsonCoefficients(wilson.Wilson):
     """
     def __init__(self):
         self.wc = None
+        self._options = {}
+
+    def __hash__(self):
+        """Return a hash of the `WilsonCoefficient` instance.
+
+        The hash changes when Wilson coefficient values or options are modified.
+        It assumes that `wcxf.WC` instances are not modified after instantiation."""
+        return hash((self.wc, frozenset(self._options)))
 
     def set_initial(self, wc_dict, scale, eft='WET', basis='flavio'):
         """Set initial values of Wilson coefficients.

--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -60,7 +60,8 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         self.exclude_measurements = exclude_measurements
         self.include_measurements = include_measurements
         self.include_pseudo_measurements = include_pseudo_measurements
-        self.predictions_cache = (None, None)
+        self._predictions_cache_hash = None
+        self._predictions_cache_values = None
         if exclude_measurements and include_measurements:
             raise ValueError("The options exclude_measurements and include_measurements must not be specified simultaneously")
 
@@ -143,15 +144,16 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         """
         # compute a hash from the function's arguments used for caching
         arg_hash = hash((frozenset(par_dict.items()),wc_obj))
-        if arg_hash != self.predictions_cache[0]:
+        if arg_hash != self._predictions_cache_hash:
             all_predictions = {}
             for observable in self.observables:
                 obs = flavio.classes.Observable.argument_format(observable, 'dict')
                 name = obs.pop('name')
                 _inst = flavio.classes.Observable[name]
                 all_predictions[observable] = _inst.prediction_par(par_dict, wc_obj, **obs)
-            self.predictions_cache = (arg_hash, all_predictions)
-        return self.predictions_cache[1]
+            self._predictions_cache_values = all_predictions
+            self._predictions_cache_hash = arg_hash
+        return self._predictions_cache_values
 
     def log_likelihood_pred(self, pred_dict):
         """Return the logarithm of the likelihood function as a function of

--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -60,7 +60,7 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         self.exclude_measurements = exclude_measurements
         self.include_measurements = include_measurements
         self.include_pseudo_measurements = include_pseudo_measurements
-        self.predictions_cache = {}
+        self.predictions_cache = (None, None)
         if exclude_measurements and include_measurements:
             raise ValueError("The options exclude_measurements and include_measurements must not be specified simultaneously")
 
@@ -139,15 +139,15 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         a parameter dictionary `par_dict`and WilsonCoefficient instance
         `wc_obj`"""
         predictions_key = (hash(frozenset(par_dict.items())),hash(wc_obj))
-        if predictions_key not in self.predictions_cache:
+        if predictions_key != self.predictions_cache[0]:
             all_predictions = {}
             for observable in self.observables:
                 obs = flavio.classes.Observable.argument_format(observable, 'dict')
                 name = obs.pop('name')
                 _inst = flavio.classes.Observable[name]
                 all_predictions[observable] = _inst.prediction_par(par_dict, wc_obj, **obs)
-            self.predictions_cache[predictions_key] = all_predictions
-        return self.predictions_cache[predictions_key]
+            self.predictions_cache = (predictions_key, all_predictions)
+        return self.predictions_cache[1]
 
     def log_likelihood_pred(self, pred_dict):
         """Return the logarithm of the likelihood function as a function of

--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -137,16 +137,20 @@ class MeasurementLikelihood(iio.YAMLLoadable):
     def get_predictions_par(self, par_dict, wc_obj):
         """Compute the predictions for all observables as functions of
         a parameter dictionary `par_dict`and WilsonCoefficient instance
-        `wc_obj`"""
-        predictions_key = hash((frozenset(par_dict.items()),wc_obj))
-        if predictions_key != self.predictions_cache[0]:
+        `wc_obj`.
+        The latest computed values are cached and returned if the function is
+        called successively with the same arguments.
+        """
+        # compute a hash from the function's arguments used for caching
+        arg_hash = hash((frozenset(par_dict.items()),wc_obj))
+        if arg_hash != self.predictions_cache[0]:
             all_predictions = {}
             for observable in self.observables:
                 obs = flavio.classes.Observable.argument_format(observable, 'dict')
                 name = obs.pop('name')
                 _inst = flavio.classes.Observable[name]
                 all_predictions[observable] = _inst.prediction_par(par_dict, wc_obj, **obs)
-            self.predictions_cache = (predictions_key, all_predictions)
+            self.predictions_cache = (arg_hash, all_predictions)
         return self.predictions_cache[1]
 
     def log_likelihood_pred(self, pred_dict):

--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -138,7 +138,7 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         """Compute the predictions for all observables as functions of
         a parameter dictionary `par_dict`and WilsonCoefficient instance
         `wc_obj`"""
-        predictions_key = (hash(frozenset(par_dict.items())),hash(wc_obj))
+        predictions_key = hash((frozenset(par_dict.items()),wc_obj))
         if predictions_key != self.predictions_cache[0]:
             all_predictions = {}
             for observable in self.observables:

--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -138,7 +138,7 @@ class MeasurementLikelihood(iio.YAMLLoadable):
         """Compute the predictions for all observables as functions of
         a parameter dictionary `par_dict`and WilsonCoefficient instance
         `wc_obj`"""
-        predictions_key = (hash(frozenset(par_dict.items())),wc_obj.__hash__())
+        predictions_key = (hash(frozenset(par_dict.items())),hash(wc_obj))
         if predictions_key not in self.predictions_cache:
             all_predictions = {}
             for observable in self.observables:


### PR DESCRIPTION
This PR implements caching for predictions of observables inside a `MeasurementLikelihood` instance.