### PR TITLE
fix bug preventing loading of exp covariances

### DIFF
--- a/flavio/statistics/likelihood.py
+++ b/flavio/statistics/likelihood.py
@@ -535,12 +535,12 @@ class MeasurementCovariance(object):
         assert len(permutation) == len(ml.observables), \
             "Covariance matrix does not contain all necessary entries"
         if len(permutation) == 1:
-            self._exp_central_covariance = (
+            self._central_cov = (
                 d['central'],
                 d['covariance']
             )
         else:
-            self._exp_central_covariance = (
+            self._central_cov = (
                 d['central'][permutation],
                 d['covariance'][permutation][:, permutation],
             )


### PR DESCRIPTION
The `MeasurementCovariance` class uses the private attribute `_central_cov` to store the central values and covariance matrix. The method `get` tries to return the content of `_central_cov` and recomputes the covariance if this attribute is `None`.
The method `load_dict`, however, had saved the loaded central values and covariance matrix in *another* private attribute `_exp_central_covariance`. So after loading, the attribute `_central_cov` was still `None` and the method `get` recomputed the covariance. This behavior is fixed in the present PR by changing `_exp_central_covariance` in `load_dict` to `_central_cov`.