### PR TITLE
Fixes import error from recent scipy upgrade (issue #110)

### DIFF
--- a/flavio/math/integrate.py
+++ b/flavio/math/integrate.py
@@ -1,7 +1,10 @@
 import scipy
 import numpy as np
 import warnings
-from scipy.integrate.quadrature import AccuracyWarning
+try:
+    from scipy.integrate import AccuracyWarning # scipy >= 1.5.0
+except ImportError:
+    from scipy.integrate.quadrature import AccuracyWarning # scipy <= 1.4.1
 
 def nintegrate(f, a, b, epsrel=0.005, **kwargs):
     with warnings.catch_warnings():


### PR DESCRIPTION
Peter's suggested fix.
I didn't do David's idea of 
```python
warnings.filterwarnings("ignore", module="scipy.integrate")
```
(I agree it looks like it should work, but haven't tried it) since `scipy.integrate` also has an `IntegrationWarning` that we might not want to catch.