### PR TITLE
enable contour plots with true minimum

### DIFF
--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -662,6 +662,9 @@ def contour(x, y, z, levels, z_min=None,
                       "different from the minimum on the grid. For better "
                       "precision, the actual minimum should be provided in the "
                       "`z_min` argument.")
+    elif np.min(z) < z_min:
+        raise ValueError("The provided minimum `z_min` has to be smaller than "
+                         "the smallest `z` value on the grid.")
     z_min = z_min or np.min(z) # use provided minimum or minmum on the grid
     z = z - z_min # subtract z minimum to make value of new z minimum 0
     if interpolation_factor > 1:

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -687,7 +687,8 @@ def contour(x, y, z, levels, z_min=None,
     _contour_args.update(contour_args)
     _contourf_args.update(contourf_args)
     # for the filling, need to add zero contour
-    levelsf = [0] + list(levels)
+    zero_contour = min(np.min(z),np.min(levels)*(1-1e-16))
+    levelsf = [zero_contour] + list(levels)
     ax = plt.gca()
     if filled:
         ax.contourf(x, y, z, levels=levelsf, **_contourf_args)

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -662,10 +662,10 @@ def contour(x, y, z, levels, z_min=None,
                       "different from the minimum on the grid. For better "
                       "precision, the actual minimum should be provided in the "
                       "`z_min` argument.")
+        z_min = np.min(z) # use minmum on the grid
     elif np.min(z) < z_min:
         raise ValueError("The provided minimum `z_min` has to be smaller than "
                          "the smallest `z` value on the grid.")
-    z_min = z_min or np.min(z) # use provided minimum or minmum on the grid
     z = z - z_min # subtract z minimum to make value of new z minimum 0
     if interpolation_factor > 1:
         x = scipy.ndimage.zoom(x, zoom=interpolation_factor, order=1)

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -503,6 +503,7 @@ def density_contour(x, y, covariance_factor=None, n_bins=None, n_sigma=(1, 2),
     """
     data = density_contour_data(x=x, y=y, covariance_factor=covariance_factor,
                                 n_bins=n_bins, n_sigma=n_sigma)
+    data['z_min'] = np.min(data['z']) # set minimum to prevent warning
     data.update(kwargs) #  since we cannot do **data, **kwargs in Python <3.5
     return contour(**data)
 
@@ -548,7 +549,6 @@ def likelihood_contour_data(log_likelihood, x_min, x_max, y_min, y_max,
                                 "in particular, you cannot use lambda expressions.")
         pool.close()
         pool.join()
-    z = z - np.min(z) # subtract the best fit point (on the grid)
 
     # get the correct values for 2D confidence/credibility contours for n sigma
     if isinstance(n_sigma, Number):
@@ -621,7 +621,7 @@ def band_plot(log_likelihood, x_min, x_max, y_min, y_max,
     return contour_kwargs['x'], contour_kwargs['y'], contour_kwargs['z']
 
 
-def contour(x, y, z, levels,
+def contour(x, y, z, levels, z_min=None,
               interpolation_factor=1,
               interpolation_order=2,
               col=None, color=None, label=None,
@@ -634,10 +634,12 @@ def contour(x, y, z, levels,
 
     - `x`, `y`: 2D arrays containg x and y values as returned by numpy.meshgrid
     - `z` value of the function to plot. 2D array in the same shape as `x` and
-      `y`. The lowest value of the function should be 0 (i.e. the best fit
-      point).
+      `y`.
     - levels: list of function values where to draw the contours. They should
       be positive and in ascending order.
+    - `z_min` (optional): lowest value of the function to plot (i.e. value at
+      the best fit point). If not provided, the smallest value on the grid is
+      used.
     - `interpolation factor` (optional): in between the points on the grid,
       the functioncan be interpolated to get smoother contours.
       This parameter sets the number of subdivisions (default: 1, i.e. no
@@ -653,6 +655,15 @@ def contour(x, y, z, levels,
        to matplotlib.pyplot.contourf() (that paints the contour filling).
        Ignored if `filled` is false.
     """
+    if z_min is None:
+        warnings.warn("The smallest `z` value on the grid will be used as the "
+                      "minimum of the function to plot. This can lead to "
+                      "undesired results if the actual minimum is considerably "
+                      "different from the minimum on the grid. For better "
+                      "precision, the actual minimum should be provided in the "
+                      "`z_min` argument.")
+    z_min = z_min or np.min(z) # use provided minimum or minmum on the grid
+    z = z - z_min # subtract z minimum to make value of new z minimum 0
     if interpolation_factor > 1:
         x = scipy.ndimage.zoom(x, zoom=interpolation_factor, order=1)
         y = scipy.ndimage.zoom(y, zoom=interpolation_factor, order=1)
@@ -673,7 +684,7 @@ def contour(x, y, z, levels,
     _contour_args.update(contour_args)
     _contourf_args.update(contourf_args)
     # for the filling, need to add zero contour
-    levelsf = [np.min(z)] + list(levels)
+    levelsf = [0] + list(levels)
     ax = plt.gca()
     if filled:
         ax.contourf(x, y, z, levels=levelsf, **_contourf_args)

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -621,7 +621,7 @@ def band_plot(log_likelihood, x_min, x_max, y_min, y_max,
     return contour_kwargs['x'], contour_kwargs['y'], contour_kwargs['z']
 
 
-def contour(x, y, z, levels, z_min=None,
+def contour(x, y, z, levels, *, z_min=None,
               interpolation_factor=1,
               interpolation_order=2,
               col=None, color=None, label=None,

--- a/flavio/plots/test_plotfunctions.py
+++ b/flavio/plots/test_plotfunctions.py
@@ -148,7 +148,7 @@ class TestPlots(unittest.TestCase):
         self.assertEqual(data['z'].shape, (20,20))
         self.assertEqual(len(data['levels']), 1) # by default, plot 1 sigma contour
         self.assertAlmostEqual(data['levels'][0], 2.3, delta=0.01) #
-        self.assertEqual(np.min(data['z']), 0)
+        self.assertAlmostEqual(np.min(data['z']), 0.07202216) # keep value of mininum
         # test parallel computation
         data2 = likelihood_contour_data(dummy_loglikelihood,
                                         -2, 2, -3, 3, threads=2)

--- a/flavio/plots/test_plotfunctions.py
+++ b/flavio/plots/test_plotfunctions.py
@@ -153,6 +153,11 @@ class TestPlots(unittest.TestCase):
         data2 = likelihood_contour_data(dummy_loglikelihood,
                                         -2, 2, -3, 3, threads=2)
         npt.assert_array_equal(data2['z'], data['z'])
+        # check that `z_min` larger than `np.min(z)` raises error
+        with self.assertRaises(ValueError):
+            kwargs = {'z_min':0.1}
+            kwargs.update(data) #  since we cannot do **data, **kwargs in Python <3.5
+            contour(**kwargs)
 
     def test_smooth_histogram(self):
         # just check this doesn't raise and error


### PR DESCRIPTION
This PR allows using an exact minimum determined by numerical minimization in contour plots generated by the `flavio.plots.contour` function. To this end, the `flavio.plots.likelihood_contour_data` now returns its `z`-values without subtracting the lowest `z`-value on the grid.

Consequently, the output of `flavio.plots.likelihood_contour_data` is not backward compatible with older versions of `flavio.plots.contour`. However, I don't see a reason why one should generate data with the new version but plot this data with an old version.
On the other hand, `flavio.plots.contour` is fully backward compatible in the sense that plot data generated by old versions of `flavio.plots.likelihood_contour_data` can still be plotted with the new version of `flavio.plots.contour`.
Furthermore, both `flavio.plots.contour` and `flavio.plots.likelihood_contour_data` are backward compatible in the sense that code written for the old versions of these functions will still work with the new versions.

(The only exception is calling `flavio.plots.contour` and using the argument `interpolation_factor` not as a keyword argument. i.e. if the function is called as `contour(x, y, z, levels, interpolation_factor)` instead of `contour(x, y, z, levels, interpolation_factor=interpolation_factor)`, then this yields unexpected results in the new version since the 5th argument of `flavio.plots.contour` now is `z_min`. This could be avoided if `z_min` is made the last argument and all other arguments are kept in their previous order. However, I thought that `z_min` might be a rather frequently used argument and function calls like `contour(x, y, z, levels, z_min)` could be convenient. But I am not completely sure about this. @DavidMStraub do you have an opinion on that?)