### PR TITLE
Some LEP measurement updates 

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -7738,7 +7738,7 @@ ISTRA+ Kl3 2003:
     RT(K->pimunu): -0.0007(71)
 
 PDG Lambda->plnu:
-  inspire:
+  inspire: Zyla:2020zbs
   values:
     g1/f1(Lambda->penu): -0.718(15)
 

--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -5939,6 +5939,16 @@ A_l SLD:
                 [1.0, 0.007],
                 [1.0]]
 
+LEP Z leptonic decay:
+  experiment: LEP
+  inspire: ALEPH:2005ab
+  description: Table 7.1
+  values:
+    Gamma(Z->nunu): 165.8 +- 0.8 e-3 # Width per neutrino species without assuming LFU
+    Gamma(Z->ee): 83.92 +- 0.12 e-3
+    Gamma(Z->mumu): 83.99 +- 0.18 e-3
+    Gamma(Z->tautau): 84.08 +- 0.22 e-3
+    
 LHCb W->lnu 2016:
   experiment: LHCb
   inspire: Aaij:2016qqz
@@ -6023,10 +6033,14 @@ OPAL Z LFV:
 LEP W->leptons:
   experiment: LEP
   inspire: Schael:2013ita
+  description: Table 5.5 and Equations (5.2)-(5.4)
   values:
     BR(W->enu): 10.71 ± 0.16 e-2
     BR(W->munu): 10.63 ± 0.15 e-2
     BR(W->taunu): 11.38 ± 0.21 e-2
+    Rmue(W->lnu): 0.993 +- 0.019
+    Rtaue(W->lnu): 1.063 +- 0.027
+    Rtaumu(W->lnu): 1.070 +- 0.026
 
 PDG W width:
   inspire: Patrignani:2016xqp


### PR DESCRIPTION
I've added some LEP Z and W leptonic decay measurements which were missing, and which we decided to include to make flavio more complete even at the expense of having a consistent set of data.

Also, one measurement didn't have an inspire reference (the only one if my regexp was correct), so I added that.