### PR TITLE
fix implementation of mu-e conversion

### DIFF
--- a/flavio/physics/mudecays/mueconversion.py
+++ b/flavio/physics/mudecays/mueconversion.py
@@ -9,13 +9,13 @@ def CR_mue(wc_obj, par, nucl):
   mm = par['m_mu']
   scale = flavio.config['renormalization scale']['mudecays']
   #####overlap integrals and other parameters#####
-  # GuV = par['GuV']
-  # GdV = par['GdV']
-  # GsV = par['GsV']
   pc = proton_charges(par, scale)
-  GuS = (pc['gS_u+d'] + pc['gS_u-d']) / 2
-  GdS = (pc['gS_u+d'] - pc['gS_u-d']) / 2
-  GsS = pc['gS_s']
+  GuSp = (pc['gS_u+d'] + pc['gS_u-d']) / 2
+  GdSp = (pc['gS_u+d'] - pc['gS_u-d']) / 2
+  GsSp = pc['gS_s']
+  GuSn = GdSp
+  GdSn = GuSp
+  GsSn = GsSp
   D   = par['D ' +nucl]*mm**(5/2)
   Sp  = par['Sp '+nucl]*mm**(5/2)
   Vp  = par['Vp '+nucl]*mm**(5/2)
@@ -25,28 +25,29 @@ def CR_mue(wc_obj, par, nucl):
   #####Wilson Coefficients######
   #####Conversion Rate obtained from hep-ph/0203110#####
   wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
-  AL = np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_emu'].conjugate()
-  AR = np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_mue']
-  gRV = {'u': 4*(wc['CVRR_mueuu'] + wc['CVLR_mueuu']),
-         'd': 4*(wc['CVRR_muedd'] + wc['CVLR_muedd']),
-         's': 4*(wc['CVRR_muess'] + wc['CVLR_muess'])}
-  gLV = {'u': 4*(wc['CVLR_uumue'] + wc['CVLL_mueuu']),
-         'd': 4*(wc['CVLR_ddmue'] + wc['CVLL_muedd']),
-         's': 4*(wc['CVLR_ssmue'] + wc['CVLL_muess'])}
-  gRS = {'u': 4*(wc['CSRR_emuuu'].conjugate() + wc['CSRL_mueuu']),
-         'd': 4*(wc['CSRR_emudd'].conjugate() + wc['CSRL_muedd']),
-         's': 4*(wc['CSRR_emuss'].conjugate() + wc['CSRL_muess'])}
-  gLS = {'u': 4*(wc['CSRL_emuuu'].conjugate() + wc['CSRR_mueuu']),
-         'd': 4*(wc['CSRL_emudd'].conjugate() + wc['CSRR_muedd']),
-         's': 4*(wc['CSRL_emuss'].conjugate() + wc['CSRR_muess'])}
+  AL = -np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_emu']
+  AR = -np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_mue'].conjugate()
+  prefac = -np.sqrt(2)/par['GF']
+  gRV = {'u': prefac * ( wc['CVRR_mueuu'] + wc['CVLR_uumue'] ) / 2,
+         'd': prefac * ( wc['CVRR_muedd'] + wc['CVLR_ddmue'] ) / 2,
+         's': prefac * ( wc['CVRR_muess'] + wc['CVLR_ssmue'] ) / 2}
+  gLV = {'u': prefac * ( wc['CVLR_mueuu'] + wc['CVLL_mueuu'] ) / 2,
+         'd': prefac * ( wc['CVLR_muedd'] + wc['CVLL_muedd'] ) / 2,
+         's': prefac * ( wc['CVLR_muess'] + wc['CVLL_muess'] ) / 2}
+  gRS = {'u': prefac * ( wc['CSRR_emuuu'] + wc['CSRL_emuuu'] ).conjugate() / 2,
+         'd': prefac * ( wc['CSRR_emudd'] + wc['CSRL_emudd'] ).conjugate() / 2,
+         's': prefac * ( wc['CSRR_emuss'] + wc['CSRL_emuss'] ).conjugate() / 2}
+  gLS = {'u': prefac * ( wc['CSRR_mueuu'] + wc['CSRL_mueuu'] ) / 2,
+         'd': prefac * ( wc['CSRR_muedd'] + wc['CSRL_muedd'] ) / 2,
+         's': prefac * ( wc['CSRR_muess'] + wc['CSRL_muess'] ) / 2}
   lhc = (AR.conjugate()*D + (2*gLV['u'] + gLV['d'])*Vp
          +(gLV['u'] + 2*gLV['d'])*Vn
-         + (GuS* gLS['u'] + GdS*gLS['d'] + GsS*gLS['s'])*Sp
-         + (GuS*gLS['u'] + GdS*gLS['d'] + GsS*gLS['s'])*Sn)
+         + (GuSp* gLS['u'] + GdSp*gLS['d'] + GsSp*gLS['s'])*Sp
+         + (GuSn*gLS['u'] + GdSn*gLS['d'] + GsSn*gLS['s'])*Sn)
   rhc = (AL.conjugate()*D + (2*gRV['u'] + gRV['d'])*Vp
          +(gRV['u'] + 2*gRV['d'])*Vn
-         + (GuS* gRS['u'] + GdS*gRS['d'] + GsS*gRS['s'])*Sp
-         + (GuS*gRS['u'] + GdS*gRS['d'] + GsS*gRS['s'])*Sn)
+         + (GuSp* gRS['u'] + GdSp*gRS['d'] + GsSp*gRS['s'])*Sp
+         + (GuSn*gRS['u'] + GdSn*gRS['d'] + GsSn*gRS['s'])*Sn)
   return 2*(par['GF']**2)*(abs(lhc)**2 + abs(rhc)**2)/GC
 
 

--- a/flavio/physics/mudecays/mueconversion.py
+++ b/flavio/physics/mudecays/mueconversion.py
@@ -25,9 +25,9 @@ def CR_mue(wc_obj, par, nucl):
   #####Wilson Coefficients######
   #####Conversion Rate obtained from hep-ph/0203110#####
   wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
-  AL = -np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_emu']
-  AR = -np.sqrt(2)/(4*par['GF']*mm)*wc['Cgamma_mue'].conjugate()
   prefac = -np.sqrt(2)/par['GF']
+  AL = prefac / ( 4 * mm ) * wc['Cgamma_emu']
+  AR = prefac / ( 4 * mm ) * wc['Cgamma_mue'].conjugate()
   gRV = {'u': prefac * ( wc['CVRR_mueuu'] + wc['CVLR_uumue'] ) / 2,
          'd': prefac * ( wc['CVRR_muedd'] + wc['CVLR_ddmue'] ) / 2,
          's': prefac * ( wc['CVRR_muess'] + wc['CVLR_ssmue'] ) / 2}

--- a/flavio/physics/mudecays/mueconversion.py
+++ b/flavio/physics/mudecays/mueconversion.py
@@ -21,7 +21,7 @@ def CR_mue(wc_obj, par, nucl):
     Vp  = par['Vp '+nucl]*mm**(5/2)
     Sn  = par['Sn '+nucl]*mm**(5/2)
     Vn  = par['Vn '+nucl]*mm**(5/2)
-    GC  = par['GammaCapture '+nucl]
+    omega_capt  = par['GammaCapture '+nucl]
     #####Wilson Coefficients######
     #####Conversion Rate obtained from hep-ph/0203110#####
     wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
@@ -62,7 +62,8 @@ def CR_mue(wc_obj, par, nucl):
         + ( GuSp * gRS['u'] + GdSp * gRS['d'] + GsSp * gRS['s'] ) * Sp
         + ( GuSn * gRS['u'] + GdSn * gRS['d'] + GsSn * gRS['s'] ) * Sn
     )
-    return 2 * par['GF']**2 * ( abs(lhc)**2 + abs(rhc)**2 ) / GC
+    omega_conv = 2 * par['GF']**2 * ( abs(lhc)**2 + abs(rhc)**2 )
+    return omega_conv / omega_capt
 
 
 def CR_mueAu(wc_obj, par):

--- a/flavio/physics/mudecays/mueconversion.py
+++ b/flavio/physics/mudecays/mueconversion.py
@@ -5,61 +5,75 @@ from flavio.physics.edms.common import proton_charges
 
 r"""Functions for neutrinoless $\mu - e$ conversion in different target nuclei"""
 def CR_mue(wc_obj, par, nucl):
-  r"""Conversion rate independent of the target nucleus"""
-  mm = par['m_mu']
-  scale = flavio.config['renormalization scale']['mudecays']
-  #####overlap integrals and other parameters#####
-  pc = proton_charges(par, scale)
-  GuSp = (pc['gS_u+d'] + pc['gS_u-d']) / 2
-  GdSp = (pc['gS_u+d'] - pc['gS_u-d']) / 2
-  GsSp = pc['gS_s']
-  GuSn = GdSp
-  GdSn = GuSp
-  GsSn = GsSp
-  D   = par['D ' +nucl]*mm**(5/2)
-  Sp  = par['Sp '+nucl]*mm**(5/2)
-  Vp  = par['Vp '+nucl]*mm**(5/2)
-  Sn  = par['Sn '+nucl]*mm**(5/2)
-  Vn  = par['Vn '+nucl]*mm**(5/2)
-  GC  = par['GammaCapture '+nucl]
-  #####Wilson Coefficients######
-  #####Conversion Rate obtained from hep-ph/0203110#####
-  wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
-  prefac = -np.sqrt(2)/par['GF']
-  AL = prefac / ( 4 * mm ) * wc['Cgamma_emu']
-  AR = prefac / ( 4 * mm ) * wc['Cgamma_mue'].conjugate()
-  gRV = {'u': prefac * ( wc['CVRR_mueuu'] + wc['CVLR_uumue'] ) / 2,
-         'd': prefac * ( wc['CVRR_muedd'] + wc['CVLR_ddmue'] ) / 2,
-         's': prefac * ( wc['CVRR_muess'] + wc['CVLR_ssmue'] ) / 2}
-  gLV = {'u': prefac * ( wc['CVLR_mueuu'] + wc['CVLL_mueuu'] ) / 2,
-         'd': prefac * ( wc['CVLR_muedd'] + wc['CVLL_muedd'] ) / 2,
-         's': prefac * ( wc['CVLR_muess'] + wc['CVLL_muess'] ) / 2}
-  gRS = {'u': prefac * ( wc['CSRR_emuuu'] + wc['CSRL_emuuu'] ).conjugate() / 2,
-         'd': prefac * ( wc['CSRR_emudd'] + wc['CSRL_emudd'] ).conjugate() / 2,
-         's': prefac * ( wc['CSRR_emuss'] + wc['CSRL_emuss'] ).conjugate() / 2}
-  gLS = {'u': prefac * ( wc['CSRR_mueuu'] + wc['CSRL_mueuu'] ) / 2,
-         'd': prefac * ( wc['CSRR_muedd'] + wc['CSRL_muedd'] ) / 2,
-         's': prefac * ( wc['CSRR_muess'] + wc['CSRL_muess'] ) / 2}
-  lhc = (AR.conjugate()*D + (2*gLV['u'] + gLV['d'])*Vp
-         +(gLV['u'] + 2*gLV['d'])*Vn
-         + (GuSp* gLS['u'] + GdSp*gLS['d'] + GsSp*gLS['s'])*Sp
-         + (GuSn*gLS['u'] + GdSn*gLS['d'] + GsSn*gLS['s'])*Sn)
-  rhc = (AL.conjugate()*D + (2*gRV['u'] + gRV['d'])*Vp
-         +(gRV['u'] + 2*gRV['d'])*Vn
-         + (GuSp* gRS['u'] + GdSp*gRS['d'] + GsSp*gRS['s'])*Sp
-         + (GuSn*gRS['u'] + GdSn*gRS['d'] + GsSn*gRS['s'])*Sn)
-  return 2*(par['GF']**2)*(abs(lhc)**2 + abs(rhc)**2)/GC
+    r"""Conversion rate independent of the target nucleus"""
+    mm = par['m_mu']
+    scale = flavio.config['renormalization scale']['mudecays']
+    #####overlap integrals and other parameters#####
+    pc = proton_charges(par, scale)
+    GuSp = (pc['gS_u+d'] + pc['gS_u-d']) / 2
+    GdSp = (pc['gS_u+d'] - pc['gS_u-d']) / 2
+    GsSp = pc['gS_s']
+    GuSn = GdSp
+    GdSn = GuSp
+    GsSn = GsSp
+    D   = par['D ' +nucl]*mm**(5/2)
+    Sp  = par['Sp '+nucl]*mm**(5/2)
+    Vp  = par['Vp '+nucl]*mm**(5/2)
+    Sn  = par['Sn '+nucl]*mm**(5/2)
+    Vn  = par['Vn '+nucl]*mm**(5/2)
+    GC  = par['GammaCapture '+nucl]
+    #####Wilson Coefficients######
+    #####Conversion Rate obtained from hep-ph/0203110#####
+    wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
+    prefac = -np.sqrt(2)/par['GF']
+    AL = prefac / ( 4 * mm ) * wc['Cgamma_emu']
+    AR = prefac / ( 4 * mm ) * wc['Cgamma_mue'].conjugate()
+    gRV = {
+        'u': prefac * ( wc['CVRR_mueuu'] + wc['CVLR_uumue'] ) / 2,
+        'd': prefac * ( wc['CVRR_muedd'] + wc['CVLR_ddmue'] ) / 2,
+        's': prefac * ( wc['CVRR_muess'] + wc['CVLR_ssmue'] ) / 2,
+    }
+    gLV = {
+        'u': prefac * ( wc['CVLR_mueuu'] + wc['CVLL_mueuu'] ) / 2,
+        'd': prefac * ( wc['CVLR_muedd'] + wc['CVLL_muedd'] ) / 2,
+        's': prefac * ( wc['CVLR_muess'] + wc['CVLL_muess'] ) / 2,
+    }
+    gRS = {
+        'u': prefac * ( wc['CSRR_emuuu'] + wc['CSRL_emuuu'] ).conjugate() / 2,
+        'd': prefac * ( wc['CSRR_emudd'] + wc['CSRL_emudd'] ).conjugate() / 2,
+        's': prefac * ( wc['CSRR_emuss'] + wc['CSRL_emuss'] ).conjugate() / 2,
+    }
+    gLS = {
+        'u': prefac * ( wc['CSRR_mueuu'] + wc['CSRL_mueuu'] ) / 2,
+        'd': prefac * ( wc['CSRR_muedd'] + wc['CSRL_muedd'] ) / 2,
+        's': prefac * ( wc['CSRR_muess'] + wc['CSRL_muess'] ) / 2,
+    }
+    lhc = (
+        AR.conjugate() * D
+        + ( 2 * gLV['u'] + gLV['d'] ) * Vp
+        + ( gLV['u'] + 2 * gLV['d'] ) * Vn
+        + ( GuSp * gLS['u'] + GdSp * gLS['d'] + GsSp * gLS['s'] ) * Sp
+        + ( GuSn * gLS['u'] + GdSn * gLS['d'] + GsSn * gLS['s'] ) * Sn
+    )
+    rhc = (
+        AL.conjugate() * D
+        + ( 2 * gRV['u'] + gRV['d'] ) * Vp
+        + ( gRV['u'] + 2 * gRV['d'] ) * Vn
+        + ( GuSp * gRS['u'] + GdSp * gRS['d'] + GsSp * gRS['s'] ) * Sp
+        + ( GuSn * gRS['u'] + GdSn * gRS['d'] + GsSn * gRS['s'] ) * Sn
+    )
+    return 2 * par['GF']**2 * ( abs(lhc)**2 + abs(rhc)**2 ) / GC
 
 
 def CR_mueAu(wc_obj, par):
-  r"""Conversion rate for $\phantom k^{197}_{79} \mathrm{Au}$"""
-  return CR_mue(wc_obj, par, 'Au')
+    r"""Conversion rate for $\phantom k^{197}_{79} \mathrm{Au}$"""
+    return CR_mue(wc_obj, par, 'Au')
 def CR_mueAl(wc_obj, par):
-  r"""Conversion rate for $\phantom k^{27}_{13} \mathrm{Al}$"""
-  return CR_mue(wc_obj, par, 'Al')
+    r"""Conversion rate for $\phantom k^{27}_{13} \mathrm{Al}$"""
+    return CR_mue(wc_obj, par, 'Al')
 def CR_mueTi(wc_obj, par):
-  r"""Conversion rate for $\phantom k^{48}_{22} \mathrm{Ti}$"""
-  return CR_mue(wc_obj, par, 'Ti')
+    r"""Conversion rate for $\phantom k^{48}_{22} \mathrm{Ti}$"""
+    return CR_mue(wc_obj, par, 'Ti')
 
 CRAu = Observable('CR(mu->e, Au)')
 Prediction('CR(mu->e, Au)', CR_mueAu)


### PR DESCRIPTION
This PR corrects several errors in the implementation of mu-e conversion, in particular
- A wrong normalization was used  for `gRV`, `gLV`, `gRS`, and `gLS` as pointed out by @xmarcano in issue #126
- No distinction was made between the proton and neutron versions of `GuS`, `GdS`, and `GsS` as also pointed out in issue #126

In addition, while fixing the above issues, I found also others:
- `AL` and `AR` were proportional to a conjugated and an unconjugated flavio Wilson coefficient, respectively, while it should be the other way around
- `gRV`, `gLV`, `gRS`, and `gLS` were expressed in terms of the wrong flavio Wilson coefficients (in addition to the wrong normalization)

All of the above issues should be fixed by this PR. @xmarcano and @Broko55, could you maybe take a look and confirm that my modifications are indeed correct?
I used the expressions from https://arxiv.org/pdf/hep-ph/0203110.pdf and for the flavio Wilson coefficients I used https://wcxf.github.io/assets/pdf/WET.flavio.pdf.