### PR TITLE
K to ll' revision (fix to #138)

### DIFF
--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -9,15 +9,13 @@ from flavio.physics.common import add_dict
 from math import pi, sqrt
 
 
-def amplitudes(par, wc, l1, l2):
-    r"""Amplitudes P and S entering the $K\to\ell_1^+\ell_2^-$ observables.
+def amplitudes_weak_eigst(par, wc, l1, l2):
+    r"""Amplitudes P and S for the decay $\bar K^0\to\ell_1^+\ell_2^-$.
 
     Parameters
     ----------
-
     - `par`: parameter dictionary
     - `wc`: Wilson coefficient dictionary
-    - `K`: should be `'KL'` or `'KS'`
     - `l1` and `l2`: should be `'e'` or `'mu'`
     """
     # masses
@@ -37,6 +35,40 @@ def amplitudes(par, wc, l1, l2):
     return xi_t * P, xi_t * S
 
 
+def amplitudes(par, wc, K, l1, l2):
+    r"""Amplitudes P and S entering the $K_{L,S}\to\ell_1^+\ell_2^-$ observables.
+    
+    Parameters
+    ----------
+    
+    - `par`: parameter dictionary
+    - `wc`: Wilson coefficient dictionary
+    - `K`: should be `'KL'` or `'KS'`
+    - `l1` and `l2`: should be `'e'` or `'mu'`
+    """
+    # KL, KS are linear combinations of K0, K0bar. So are the amplitudes.
+    S_K0bar, P_K0bar = amplitudes_weak_eigs(par, wc, l1, l2)
+    if l1 != l2:
+        S_aux, P_aux = amplitudes_weak_eigs(par, wc, l2, l1)
+        S_K0 = -S_aux.conjugate()
+        P_K0 = P_aux.conjugate()
+        if 'K' == 'KL':
+            sig = +1
+        elif 'K' == 'KS':
+            sig = -1
+        S = (S_K0 + sig * S_K0bar) / 2
+        P = (P_K0 + sig * P_K0bar) / 2
+    # Save computing time for special cases. See also arXiv:1711.11030.
+    elif l1 == l2:
+        if 'K' == 'KL':
+            S = -1j * S_K0bar.imag 
+            P = P_K0bar.real
+        elif 'K' == 'KS':
+            S = -S_K0bar.real
+            P = -1j * P_K0bar.imag
+    return P, S
+
+
 def amplitudes_LD(par, K, l):
     r"""Long-distance amplitudes entering the $K\to\ell^+\ell^-$ observables."""
     ml = par['m_' + l]
@@ -53,18 +85,18 @@ def amplitudes_LD(par, K, l):
 
 def amplitudes_eff(par, wc, K, l1, l2, ld=True):
     r"""Effective amplitudes entering the $K\to\ell_1^+\ell_2^-$ observables."""
-    P, S = amplitudes(par, wc, l1, l2)
+    P, S = amplitudes(par, wc, K, l1, l2)
     if l1 != l2 or not ld:
         SLD = 0
         PLD = 0
     else:
         SLD, PLD = amplitudes_LD(par, K, l1)
-    if K == 'KS' and l1 == l2:
-        Peff = P.imag
-        Seff = S.real + SLD
-    if K == 'KL':
-        Peff = P.real + PLD
-        Seff = S.imag
+    if K == 'KS':
+        Peff = P
+        Seff = S + SLD
+    elif K == 'KL':
+        Peff = P + PLD
+        Seff = S
     return Peff, Seff
 
 

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -57,16 +57,16 @@ def amplitudes(par, wc, K, l1, l2):
             sig = +1
         elif 'K' == 'KS':
             sig = -1
-        S = (S_K0 + sig * S_K0bar) / 2
-        P = (P_K0 + sig * P_K0bar) / 2
+        S = (S_K0 + sig * S_K0bar) / sqrt(2)
+        P = (P_K0 + sig * P_K0bar) / sqrt(2)
     # Save computing time for special cases. See also arXiv:1711.11030.
     elif l1 == l2:
         if 'K' == 'KL':
-            S = -1j * S_K0bar.imag 
-            P = P_K0bar.real
+            S = -1j * S_K0bar.imag * sqrt(2)
+            P = P_K0bar.real * sqrt(2)
         elif 'K' == 'KS':
-            S = -S_K0bar.real
-            P = -1j * P_K0bar.imag
+            S = -S_K0bar.real * sqrt(2)
+            P = -1j * P_K0bar.imag * sqrt(2)
     return P, S
 
 
@@ -75,7 +75,7 @@ def amplitudes_LD(par, K, l):
     ml = par['m_' + l]
     mK = par['m_' + K]
     s2w = par['s2w']
-    pre = 2 * ml / mK / s2w
+    pre = sqrt(2) * 2 * ml / mK / s2w
     # numbers extracted from arXiv:1711.11030
     if K == 'KS':
         ASgaga = 2.49e-4 * (-2.821 + 1.216j)
@@ -133,7 +133,7 @@ def br_kll(par, wc_obj, K, l1, l2, ld=True):
     beta = sqrt(lambda_K(mK**2, ml1**2, ml2**2)) / mK**2
     beta_p = sqrt(1 - (ml1 + ml2)**2 / mK**2)
     beta_m = sqrt(1 - (ml1 - ml2)**2 / mK**2)
-    prefactor = 2 * abs(N)**2 / 32. / pi * mK**3 * tauK * beta * fK**2
+    prefactor = abs(N)**2 / 32. / pi * mK**3 * tauK * beta * fK**2
     Peff, Seff = amplitudes_eff(par, wc, K, l1, l2, ld=ld)
     return prefactor * (beta_m**2 * abs(Peff)**2 + beta_p**2 * abs(Seff)**2)
 

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -53,18 +53,18 @@ def amplitudes(par, wc, K, l1, l2):
         S_aux, P_aux = amplitudes_weak_eigst(par, wc, l2, l1)
         S_K0 = -S_aux.conjugate()
         P_K0 = P_aux.conjugate()
-        if 'K' == 'KL':
+        if K == 'KL':
             sig = +1
-        elif 'K' == 'KS':
+        elif K == 'KS':
             sig = -1
         S = (S_K0 + sig * S_K0bar) / sqrt(2)
         P = (P_K0 + sig * P_K0bar) / sqrt(2)
     # Save computing time for special cases. See also arXiv:1711.11030.
     elif l1 == l2:
-        if 'K' == 'KL':
+        if K == 'KL':
             S = -1j * S_K0bar.imag * sqrt(2)
             P = P_K0bar.real * sqrt(2)
-        elif 'K' == 'KS':
+        elif K == 'KS':
             S = -S_K0bar.real * sqrt(2)
             P = -1j * P_K0bar.imag * sqrt(2)
     return P, S

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -77,11 +77,15 @@ def amplitudes_LD(par, K, l):
     s2w = par['s2w']
     pre = 2 * ml / mK / s2w
     # numbers extracted from arXiv:1711.11030
-    ASgaga = 2.49e-4 * (-2.821 + 1.216j)
-    ALgaga = 2.02e-4 * (par['chi_disp(KL->gammagamma)'] - 5.21j)
-    S = pre * ASgaga
-    P = -pre * ALgaga
-    return S, P
+    if K == 'KS':
+        ASgaga = 2.49e-4 * (-2.821 + 1.216j)
+        SLD = +pre * ASgaga
+        PLD = 0
+    elif K == 'KL':
+        ALgaga = 2.02e-4 * (par['chi_disp(KL->gammagamma)'] - 5.21j)
+        SLD = 0
+        PLD = -pre * ALgaga
+    return SLD, PLD
 
 
 def amplitudes_eff(par, wc, K, l1, l2, ld=True):
@@ -92,12 +96,8 @@ def amplitudes_eff(par, wc, K, l1, l2, ld=True):
         PLD = 0
     else:
         SLD, PLD = amplitudes_LD(par, K, l1)
-    if K == 'KS':
-        Peff = P
-        Seff = S + SLD
-    elif K == 'KL':
-        Peff = P + PLD
-        Seff = S
+    Peff = P + PLD
+    Seff = S + SLD
     return Peff, Seff
 
 

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -73,7 +73,7 @@ def amplitudes(par, wc, K, l1, l2):
 def amplitudes_LD(par, K, l):
     r"""Long-distance amplitudes entering the $K\to\ell^+\ell^-$ observables."""
     ml = par['m_' + l]
-    mK = par['m_' + K]
+    mK = par['m_K0']
     s2w = par['s2w']
     pre = sqrt(2) * 2 * ml / mK / s2w
     # numbers extracted from arXiv:1711.11030

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -31,6 +31,7 @@ def amplitudes_weak_eigst(par, wc, l1, l2):
     CSm = wc['CS_'+qqll] - wc['CSp_'+qqll]
     P = (ml2 + ml1)/mK * C10m + mK * CPm  # neglecting mu, md
     S = (ml2 - ml1)/mK * C9m  + mK * CSm  # neglecting mu, md
+    # Include complex part of the eff. operator prefactor. Phases matter.
     xi_t = ckm.xi('t', 'sd')(par)
     return xi_t * P, xi_t * S
 
@@ -127,7 +128,7 @@ def br_kll(par, wc_obj, K, l1, l2, ld=True):
     mK = par['m_K0']
     tauK = par['tau_'+K]
     fK = par['f_K0']
-    # appropriate CKM elements
+    # CKM part of the eff. operator prefactor included in Peff and Seff
     N = 4 * GF / sqrt(2) * alphaem / (4 * pi)
     beta = sqrt(lambda_K(mK**2, ml1**2, ml2**2)) / mK**2
     beta_p = sqrt(1 - (ml1 + ml2)**2 / mK**2)

--- a/flavio/physics/kdecays/kll.py
+++ b/flavio/physics/kdecays/kll.py
@@ -48,9 +48,9 @@ def amplitudes(par, wc, K, l1, l2):
     - `l1` and `l2`: should be `'e'` or `'mu'`
     """
     # KL, KS are linear combinations of K0, K0bar. So are the amplitudes.
-    S_K0bar, P_K0bar = amplitudes_weak_eigs(par, wc, l1, l2)
+    S_K0bar, P_K0bar = amplitudes_weak_eigst(par, wc, l1, l2)
     if l1 != l2:
-        S_aux, P_aux = amplitudes_weak_eigs(par, wc, l2, l1)
+        S_aux, P_aux = amplitudes_weak_eigst(par, wc, l2, l1)
         S_K0 = -S_aux.conjugate()
         P_K0 = P_aux.conjugate()
         if 'K' == 'KL':


### PR DESCRIPTION
In the discussion in #138, we agreed that there are some bugs in Kll.py. I tried to repair them. Moreover, I commited some other small changes aiming to improve the readability of the code. 

1. The KS->e mu is no longer an invalid option in the function `amplitudes_eff`. 

2. Amplitudes for LFV decays (i.e. `l1!=l2`) were not calculated correctly. The fix needed some nontrivial extension of the code as well as some physics considerations, which I will summarize now:
-  the original function function `amplitudes` has been renamed to `amplitudes_weak_eigst` as it actually does not yield the relevant amplitudes for KL -> l1+l2- nor KS->l1+l2-, but for the decay of weak eigenstate K0bar -> l1+ l2-. 

```
   S_K0bar, P_K0bar = amplitudes_weak_eigst(par, wc, l1, l2)
```
Also the amplitude for K0->l1+l2- can be obtained from this function as
```
    S_aux, P_aux = amplitudes_weak_eigst(par, wc, l2, l1)
    S_K0 = -S_aux.conjugate()
    P_K0 = P_aux.conjugate()
```
I can attach some notes about why it is like this.
- An entirely new function `amplitudes(par, wc, K, l1, l2)` has been implemented. It simply makes proper linear combinations of amplitudes for K0 and K0bar which correspond to the approximate mass eigenstates KL, KS (in fact, CP eigenstates are used instead). In the special case `l1 == l2`, this can be simplified to the expressions with imaginary or real parts of S,P, which had been there originally, adopted from ArXiv:1711.11030 (I guess). I implemented this special case separately inside the `amplitudes`, for the reason of both effectivity and better possibility to check that the new formulae are consistent with the old ones. If the maintainers find this separate treatment  redundant, it can be removed, of course. The new  `amplitudes` function now takes `K` as a mandatory argument (to be `'KL'` or `'KS`'). 
- There is no longer a need to take real or imaginary parts of the `amplitudes` within the `amplitudes_eff` function, which now serves purely to sum the short-distance `amplitudes` with `amplitudes_LD` in the LF conserving cases. It also seems more consistent now - `amplitudes_eff` has one and only one purpose.

Furthermore, I made some additional small commits:
3. The function `amplitudes_LD(par, K, l)` was originally giving long-distance contributions for both KL and KS, although it takes `K` as an argument. Eventually, everything had been calculated correctly but the implementation seemed little awkward to me. So I've changed it in order to make things clearer.
4. I dared to change the normalization of the new short-distance `amplitudes` and `amplitudes_LD` by `sqrt(2)` and reduced the prefactor of `br_kll` by 2 accordingly. The purpose is solely to make `br_kll` more consistent with `br_inst` in ./physics/kdecays/kll.py or with arXiv:1602.00881 from which the formulae have been adopted; also, the normalization of `amplitudes` as linear combinations of `amplitudes_weak_eigst` is the standard one, following from KL = (K0+K0bar)/sqrt(2),KS = (K0-K0bar)/sqrt(2).

I also think I may have found another bug, which we haven't discussed in #138. 
5. Originally, `amplitudes_eff` for the case `K=='KS'` was was summing the effective scalar amplitude as `Seff = S.real + SLD`. However,  ArXiv:1711.11030 (which is the cited source in the code) claims that these two terms should subtract from each other (overall phase is irrelevant). `SLD` is implemented in flavio correctly according to Eq. (2.15) in 1711.11030 including the sign. Also, both flavio and 1711.11030 use the same convention for WCs: _L_eff=-H_eff=C_A O_A_. Thus, I think that originally the interference was inappropriately implemented. In my proposal it is corrected by the fact that the short-distance amplitude `S` is obtained as `-S_K0bar.real * sqrt(2)`. (The minus sign is the important thing there; the sqrt(2) relates to what I discuss above in point 4.). Note that both flavio and 1711.11030 use the same convention for WCs: _L_eff=-H_eff=C_A O_A_.
The similar issue for the case of KL (`Peff = P + PLD`) was (and still is) probably correctly handled by the extra minus sign in the definition of PLD:
```
        ALgaga = 2.02e-4 * (par['chi_disp(KL->gammagamma)'] - 5.21j)
        SLD = 0
        PLD = -pre * ALgaga
``` 
I didn't dig to details there (like what's the default sign of the parameter enteging ALgaga in flavio when in fact it is not known).