### PR TITLE
Remove matplotlib deprecation warnings

### DIFF
--- a/flavio/plots/config.py
+++ b/flavio/plots/config.py
@@ -8,4 +8,4 @@ rc('font',**{'family':'serif',
 rcParams['xtick.labelsize'] = 10
 rcParams['ytick.labelsize'] = 10
 rcParams['axes.labelsize'] = 14
-rcParams['text.latex.preamble']=[r"\usepackage{amsmath}"]
+rcParams['text.latex.preamble']=r"\usepackage{amsmath}"


### PR DESCRIPTION
Removes a slightly annoying deprecation warning.
Setting the rcparam as a list rather than a single string has been deprecated in matplotlib v3.3.0 (see https://matplotlib.org/3.3.0/api/api_changes.html#setting-rcparams-text-latex-preamble-default-or-rcparams-pdf-preamble-to-non-strings)