### PR TITLE
Add B->ee measurements

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -9533,6 +9533,13 @@ CMS Bs->mumu 2019:
       6.0264851271401515e-19, 2.858029566844475e-19]
     central_value: [2.936395136708043e-09, 7.995782608027678e-11]
 
+LHCb B->ee 2020:
+  experiment: LHCb
+  inspire: Aaij:2020nol
+  values:
+    BR(Bs->ee): < 9.4e-9 @ 90% CL
+    BR(B0->ee): < 2.5e-9 @ 90% CL
+
 Ft(0+) Hardy/Towner 2014:
   experiment: various
   inspire: Hardy:2014qxa


### PR DESCRIPTION
Hi, I would like to add the recent LHCb limits on _B0 -> e+e-_ and _Bs -> e+e-_ to flavio. These processes are important in vector LQ scenarios, for example. There has been no other measurement of these decays included in flavio so far.