### PR TITLE
Add inspire to 'LHCb KS->mumu 2019' measurement.

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -7053,7 +7053,7 @@ LHCb KS->mumu 2019:
   experiment: LHCb
   inspire: Aaij:2020sbt
   values:
-    BR(KS->mumu): 0.94 +0.72 -0.64 e-10
+    BR(KS->mumu): 0.9 +0.7 -0.6 e-10
 
 ATLAS Bs->mumu 2018:
   experiment: ATLAS

--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -7051,6 +7051,7 @@ PDG 2018 Kll:
 
 LHCb KS->mumu 2019:
   experiment: LHCb
+  inspire: Aaij:2020sbt
   values:
     BR(KS->mumu): 0.94 +0.72 -0.64 e-10
 


### PR DESCRIPTION
The measurement was only released in a preliminary report (inspire: LHCb:2019aoh) when implemented to flavio but in the meantime it has been normally published (inspire: Aaij:2020sbt).