### PR TITLE
fixed handling of subleading contributions to B->Vll decays at high q2

### DIFF
--- a/flavio/physics/bdecays/bvll/subleading.py
+++ b/flavio/physics/bdecays/bvll/subleading.py
@@ -76,9 +76,9 @@ class HelicityAmpsDeltaC_9_shift(HelicityAmpsDeltaC):
         deltaC9_pl   = par[B+'->'+V+' deltaC9 c_+ Re'] + 1j*par[B+'->'+V+' deltaC9 c_+ Im']
         deltaC9_mi   = par[B+'->'+V+' deltaC9 c_- Re'] + 1j*par[B+'->'+V+' deltaC9 c_- Im']
         ha = {}
-        ha['0', 'V'] = self.ha_deltaC(deltaC9_0, '9')['0', 'V']
-        ha['pl', 'V'] = self.ha_deltaC(deltaC9_pl, '9')['pl', 'V']
-        ha['mi', 'V'] = self.ha_deltaC(deltaC9_mi, '9')['mi', 'V']
+        ha['0', 'V'] = self.ha_deltaC(deltaC9_0, 'v')['0', 'V']
+        ha['pl', 'V'] = self.ha_deltaC(deltaC9_pl, 'v')['pl', 'V']
+        ha['mi', 'V'] = self.ha_deltaC(deltaC9_mi, 'v')['mi', 'V']
         return ha
 
 


### PR DESCRIPTION
Fixes the handling of the subleading contributions to the B->Vll decay amplitudes, as `helicity_amps_v` expects the vector coupling in `wc['v']`, not in `wc['9']`.