### PR TITLE
Removal of superfluous factors of 1/2 from the conversion of Wilson coefficients of (pseudo)scalar operators in the function get_wceff_fccc

### DIFF
--- a/flavio/physics/bdecays/wilsoncoefficients.py
+++ b/flavio/physics/bdecays/wilsoncoefficients.py
@@ -216,10 +216,10 @@ def get_wceff_fccc(wc_obj, par, qiqj, lep, nu, mqi, scale, nf=5):
     c['vp'] = wc['CVR_'+qqlnu]/2.
     c['a']  = -(c_sm + wc['CVL_'+qqlnu])/2.
     c['ap'] = -wc['CVR_'+qqlnu]/2.
-    c['s']  = 1/2 * wc['CSR_'+qqlnu]/2.
-    c['sp'] = 1/2 * wc['CSL_'+qqlnu]/2.
-    c['p']  = -1/2 * wc['CSR_'+qqlnu]/2.
-    c['pp'] = -1/2 * wc['CSL_'+qqlnu]/2.
+    c['s']  = wc['CSR_'+qqlnu]/2.
+    c['sp'] = wc['CSL_'+qqlnu]/2.
+    c['p']  = -wc['CSR_'+qqlnu]/2.
+    c['pp'] = -wc['CSL_'+qqlnu]/2.
     c['t']  = 0
     c['tp'] = wc['CT_'+qqlnu]
     return c


### PR DESCRIPTION
We had looked at the contributions of the scalar operator to the lepton-flavour universality ratios R(D) and R(D*) and noticed a discrepancy between the results output by flavio and those obtained from analytic expressions in the literature.
In the function get_wceff_fccc, there is a factor 1/2 involved in the conversion of the Wilson coefficients of the relevant scalar operators to those used for the helicity amplitudes in flavio which appears superfluous.
After removing this factor, the flavio results for R(D) and R(D*) are compatible with the literature ones. This is illustrated by the two attached plots. They show the results for R(D)/R(D)_{SM} and R(D*)/R(D*)_{SM} as functions of the scalar Wilson coefficient C_{SL} obtained via flavio and from analytic expressions used in several papers referenced in the plot legend, with the aforementioned factor of 1/2 included ("_old.png") and removed ("_new.png"), respectively. In order to exclude the possibility of RG effects playing a role, C_{SL} is defined at the bottom-quark mass scale. Furthermore, C_{SL} is chosen real and all contributions from other operators are switched off.

R(D*) without factor 1/2:

![scalaroperatorRDStar_new](https://user-images.githubusercontent.com/79946147/122532805-3d60e780-d064-11eb-9a07-fcb1a56c8d93.png)

R(D*) with factor 1/2:

![scalaroperatorRDStar_old](https://user-images.githubusercontent.com/79946147/122532810-3e921480-d064-11eb-8c31-93b188ae96cd.png)

R(D) without factor 1/2:

![scalaroperatorRD_new](https://user-images.githubusercontent.com/79946147/122532180-98dea580-d063-11eb-8893-b9d6293d5fac.png)

R(D) with factor 1/2:

![scalaroperatorRD_old](https://user-images.githubusercontent.com/79946147/122532187-9aa86900-d063-11eb-9c1f-a560bc46ba6a.png)
