### PR TITLE
Improved comment on fK and meson mixing

### DIFF
--- a/flavio/data/parameters_correlated.yml
+++ b/flavio/data/parameters_correlated.yml
@@ -28,6 +28,11 @@
 # from the FLAG lattice average of the ratio f_K/f_pi.
 # This way, lattice determinations of f_K that use the measurement of f_pi
 # to set the scale are not used.
+#
+# The f_K uncertainty and correlation are calculated by assuming f_pi and
+# f_K/f_pi are totally uncorrelated - see discussion at
+# https://github.com/flav-io/flavio/issues/171 and/or the code at
+# https://gist.github.com/DavidMStraub/813bd0c4296837936a188a29c8d8b981
 -
   values:
     - f_K+: 0.1554(10)  # reproduce f_K/f_pi=1.1932(19) from FLAG 2019 Nf=2+1+1

--- a/flavio/data/parameters_correlated.yml
+++ b/flavio/data/parameters_correlated.yml
@@ -1,4 +1,4 @@
-# This file contains paraemeter values and uncertainties for parameters
+# This file contains parameter values and uncertainties for parameters
 # that have correlated uncertainties
 
 # Quark masses from arXiv:1802.04248
@@ -20,7 +20,7 @@
 
 
 # Decay constants of charged and neutral mesons are highly correlated; in
-# fact they are equal up to isosin breaking effects.
+# fact they are equal up to isospin breaking effects.
 # for now, just assume 99% correlation
 
 # In order not to depend on the experimental value of f_pi, f_pi is taken

--- a/flavio/physics/mesonmixing/amplitude.py
+++ b/flavio/physics/mesonmixing/amplitude.py
@@ -15,6 +15,7 @@ from flavio.physics import ckm
 def matrixelements(par, meson):
     r"""Returns a dictionary with the values of the matrix elements of the
     $\Delta F=2$ operators."""
+    # Note that the factor of 2M is already taken care of here
     mM = par['m_'+meson]
     fM = par['f_'+meson]
     BM = lambda i: par['bag_' + meson + '_' + str(i)]

--- a/flavio/physics/mesonmixing/amplitude.py
+++ b/flavio/physics/mesonmixing/amplitude.py
@@ -14,8 +14,12 @@ from flavio.physics import ckm
 
 def matrixelements(par, meson):
     r"""Returns a dictionary with the values of the matrix elements of the
-    $\Delta F=2$ operators."""
-    # Note that the factor of 2M is already taken care of here
+    $\Delta F=2$ operators.
+    
+    Note that the normalisation factor 1/2M from M_12 is included here,
+    so the returned values of the matrix elements are really    
+    $$\langle Q \rangle = \frac{\langle M | Q |\bar M\rangle}{2M_M}$$
+    """
     mM = par['m_'+meson]
     fM = par['f_'+meson]
     BM = lambda i: par['bag_' + meson + '_' + str(i)]


### PR DESCRIPTION
- Added a comment to the parameter file to summarise my discussion with David in #171 
- Add a note that the meson mixing matrix element values have the 1/2M normalisation included - this is something I periodically forget in flavio, and spend a while wondering why the code is  `M * f^2 * bag` not `M^2 * f^2 * bag` before remembering. I wasn't sure whether to just add a comment in the code or alter the docstring - I decided on the docstring since someone (possibly future me again) might look there first after being confused about the values that `matrixelements` returns before looking at the source code.