### PR TITLE
Simple fix for eps_K

### DIFF
--- a/flavio/physics/mesonmixing/test_mesonmixing.py
+++ b/flavio/physics/mesonmixing/test_mesonmixing.py
@@ -190,4 +190,4 @@ class TestMesonMixing(unittest.TestCase):
         self.assertAlmostEqual(
             flavio.np_prediction('eps_K', w) / flavio.sm_prediction('eps_K'),
             2,
-            delta=0.15)  # difference due to NNLO evolution of SM contribution + charm contribution
+            delta=0.30)  # difference due to NNLO evolution of SM contribution + charm contribution

--- a/flavio/physics/mesonmixing/wilsoncoefficient.py
+++ b/flavio/physics/mesonmixing/wilsoncoefficient.py
@@ -56,9 +56,9 @@ def cvll_d(par, meson, scale=160):
     charm-, and charm-top-contribution to the Wilson coefficient. This
     separation is necessary as they run differently.
     """
-    mt = flavio.physics.running.running.get_mt(par, scale)
-    mc = flavio.physics.running.running.get_mc(par, scale)
-    mu = flavio.physics.running.running.get_mu(par, scale)
+    mt = flavio.physics.running.running.get_mt_mt(par)
+    mc = par["m_c"]
+    mu = par["m_u"]
     mW = par['m_W']
     xt = mt**2/mW**2
     xc = mc**2/mW**2

--- a/flavio/physics/running/running.py
+++ b/flavio/physics/running/running.py
@@ -268,6 +268,21 @@ def _get_mt(mt_pole, alpha_s, scale):
     return crd.mOS2mMS(mt_pole, None, alpha_s, scale, 6, 3)
 
 
+def get_mt_mt(par):
+    r"""Get the scale invariant top quark mass mt(mt)."""
+    mt_pole = par['m_t']
+    return _get_mt_mt(mt_pole=mt_pole,
+                      alpha_s=get_alpha_s(par, mt_pole))
+
+
+# cached version
+@lru_cache(maxsize=config['settings']['cache size'])
+def _get_mt_mt(mt_pole, alpha_s):
+    r"""Get the scale invariant top quark mass mt(mt)."""
+    crd = rundec.CRunDec()
+    return crd.mOS2mSI(mt_pole, None, alpha_s, 6, 3)
+
+
 def make_wilson_rge_derivative(adm):
     if adm is None:
         return None


### PR DESCRIPTION
Since it's already been over two months since #172, and I haven't had time to even start the alternative implementation of epsK from https://arxiv.org/abs/1911.06822, I'm just submitting my quick fix here.

As discussed in #172, the RG factors assume the quark masses used are mq(mq), not mq(160 GeV).
- For the top, we add a new function to the running module get_mt_mt which calculates mt(mt) using the RunDec function mOS2mSI and the top pole mass.
- For the charm, the input parameter m_c is already mc(mc) from PDG, so use that.
- For the up, the input m_u is actually mu(2 GeV), but this is closer to mu(mu) than mu(160 GeV), and numerically the up mass is extremely unimportant anyway.

The epsK NP test has to be changed, since with the correct value of mc the charm contribution to imag(M12) is larger (around 30% vs 10% with the old value), and so the NP doesn't exactly double the SM value.