### PR TITLE
Include new nuclear uncertainties in beta decays

### DIFF
--- a/flavio/data/parameters_metadata.yml
+++ b/flavio/data/parameters_metadata.yml
@@ -1993,7 +1993,7 @@ deltaRp_n:
   description: Long-distance radiative correction to neutron beta decay
 delta_deltaRp_Z2:
   tex: $\delta(\delta R^\prime) / Z^2$
-  description: Uncertainty on the structure-indipendent radiative correction to beta decay divided by $Z^2$
+  description: Uncertainty on the structure-independent radiative correction to beta decay divided by $Z^2$
 delta_deltaNS 10C:
   tex: $\delta(\delta_{NS}) ({}^{10}\text{C})
   description: Uncertainty on the nuclear structure dependent corrections to ${}^{10}\text{C}$ beta decay

--- a/flavio/data/parameters_metadata.yml
+++ b/flavio/data/parameters_metadata.yml
@@ -1993,7 +1993,49 @@ deltaRp_n:
   description: Long-distance radiative correction to neutron beta decay
 delta_deltaRp_Z2:
   tex: $\delta(\delta R^\prime) / Z^2$
-  description: Uncertainty on the structure-indipendent radiative correction to beta decay divided by $Z^2
+  description: Uncertainty on the structure-indipendent radiative correction to beta decay divided by $Z^2$
+delta_deltaNS 10C:
+  tex: $\delta(\delta_{NS}) ({}^{10}\text{C})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{10}\text{C}$ beta decay
+delta_deltaNS 14O:
+  tex: $\delta(\delta_{NS}) ({}^{14}\text{O})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{14}\text{O}$ beta decay
+delta_deltaNS 22Mg:
+  tex: $\delta(\delta_{NS}) ({}^{22}\text{Mg})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{22}\text{Mg}$ beta decay
+delta_deltaNS 26mAl:
+  tex: $\delta(\delta_{NS}) ({}^{26m}\text{Al})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{26m}\text{Al}$ beta decay
+delta_deltaNS 34Cl:
+  tex: $\delta(\delta_{NS}) ({}^{34}\text{Cl})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{34}\text{Cl}$ beta decay
+delta_deltaNS 34Ar:
+  tex: $\delta(\delta_{NS}) ({}^{34}\text{Ar})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{34}\text{Ar}$ beta decay
+delta_deltaNS 38mK:
+  tex: $\delta(\delta_{NS}) ({}^{38m}\text{K})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{38m}\text{K}$ beta decay
+delta_deltaNS 38Ca:
+  tex: $\delta(\delta_{NS}) ({}^{38}\text{Ca})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{38}\text{Ca}$ beta decay
+delta_deltaNS 42Sc:
+  tex: $\delta(\delta_{NS}) ({}^{42}\text{Sc})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{42}\text{Sc}$ beta decay
+delta_deltaNS 46V:
+  tex: $\delta(\delta_{NS}) ({}^{46}\text{V})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{46}\text{V}$ beta decay
+delta_deltaNS 50Mn:
+  tex: $\delta(\delta_{NS}) ({}^{50}\text{Mn})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{50}\text{Mn}$ beta decay
+delta_deltaNS 54Co:
+  tex: $\delta(\delta_{NS}) ({}^{54}\text{Co})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{54}\text{Co}$ beta decay
+delta_deltaNS 62Ga:
+  tex: $\delta(\delta_{NS}) ({}^{62}\text{Ga})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{62}\text{Ga}$ beta decay
+delta_deltaNS 74Rb:
+  tex: $\delta(\delta_{NS}) ({}^{74}\text{Rb})
+  description: Uncertainty on the nuclear structure dependent corrections to ${}^{74}\text{Rb}$ beta decay
 f_n:
   tex: $f_n$
   description: Statistical rate function for neutron beta decay

--- a/flavio/data/parameters_metadata.yml
+++ b/flavio/data/parameters_metadata.yml
@@ -1994,48 +1994,12 @@ deltaRp_n:
 delta_deltaRp_Z2:
   tex: $\delta(\delta R^\prime) / Z^2$
   description: Uncertainty on the structure-independent radiative correction to beta decay divided by $Z^2$
-delta_deltaNS 10C:
-  tex: $\delta(\delta_{NS}) ({}^{10}\text{C})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{10}\text{C}$ beta decay
-delta_deltaNS 14O:
-  tex: $\delta(\delta_{NS}) ({}^{14}\text{O})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{14}\text{O}$ beta decay
-delta_deltaNS 22Mg:
-  tex: $\delta(\delta_{NS}) ({}^{22}\text{Mg})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{22}\text{Mg}$ beta decay
-delta_deltaNS 26mAl:
-  tex: $\delta(\delta_{NS}) ({}^{26m}\text{Al})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{26m}\text{Al}$ beta decay
-delta_deltaNS 34Cl:
-  tex: $\delta(\delta_{NS}) ({}^{34}\text{Cl})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{34}\text{Cl}$ beta decay
-delta_deltaNS 34Ar:
-  tex: $\delta(\delta_{NS}) ({}^{34}\text{Ar})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{34}\text{Ar}$ beta decay
-delta_deltaNS 38mK:
-  tex: $\delta(\delta_{NS}) ({}^{38m}\text{K})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{38m}\text{K}$ beta decay
-delta_deltaNS 38Ca:
-  tex: $\delta(\delta_{NS}) ({}^{38}\text{Ca})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{38}\text{Ca}$ beta decay
-delta_deltaNS 42Sc:
-  tex: $\delta(\delta_{NS}) ({}^{42}\text{Sc})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{42}\text{Sc}$ beta decay
-delta_deltaNS 46V:
-  tex: $\delta(\delta_{NS}) ({}^{46}\text{V})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{46}\text{V}$ beta decay
-delta_deltaNS 50Mn:
-  tex: $\delta(\delta_{NS}) ({}^{50}\text{Mn})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{50}\text{Mn}$ beta decay
-delta_deltaNS 54Co:
-  tex: $\delta(\delta_{NS}) ({}^{54}\text{Co})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{54}\text{Co}$ beta decay
-delta_deltaNS 62Ga:
-  tex: $\delta(\delta_{NS}) ({}^{62}\text{Ga})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{62}\text{Ga}$ beta decay
-delta_deltaNS 74Rb:
-  tex: $\delta(\delta_{NS}) ({}^{74}\text{Rb})
-  description: Uncertainty on the nuclear structure dependent corrections to ${}^{74}\text{Rb}$ beta decay
+delta_deltaNS,A:
+  tex: 
+  description: 
+delta_deltaNS,E:
+  tex: 
+  description: 
 f_n:
   tex: $f_n$
   description: Statistical rate function for neutron beta decay

--- a/flavio/data/parameters_metadata.yml
+++ b/flavio/data/parameters_metadata.yml
@@ -1995,11 +1995,11 @@ delta_deltaRp_Z2:
   tex: $\delta(\delta R^\prime) / Z^2$
   description: Uncertainty on the structure-independent radiative correction to beta decay divided by $Z^2$
 delta_deltaNS,A:
-  tex: 
-  description: 
-delta_deltaNS,E:
-  tex: 
-  description: 
+  tex: $\delta(\delta_{NS,A}$
+  description: Uncertainty on the nuclear structure dependent corrections from quenching in nuclei
+delta_deltaNS,E_QEC:
+  tex: $\delta(\delta_{NS,E} / Q_{EC}$
+  description: Uncertainty on the nuclear structure dependent corrections from nuclear polarizabilities divided by $Q_{EC}$
 f_n:
   tex: $f_n$
   description: Statistical rate function for neutron beta decay

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -525,6 +525,21 @@ DeltaRV: 0.02467(27)  # Average from 2208.11707
 # one third of the Z^2alpha^3 term in table V of 0710.3181,
 # as suggested in 1411.5987
 delta_deltaRp_Z2: 0 ± 0.00004e-2
+# Systematic errors on delta_NS from table XI of Hardy:2020qwl
+delta_deltaNS 10C:   0 +- 0.036e-2
+delta_deltaNS 14O:   0 +- 0.040e-2
+delta_deltaNS 22Mg:  0 +- 0.046e-2
+delta_deltaNS 26mAl: 0 +- 0.047e-2
+delta_deltaNS 34Cl:  0 +- 0.055e-2
+delta_deltaNS 34Ar:  0 +- 0.058e-2
+delta_deltaNS 38mK:  0 +- 0.058e-2
+delta_deltaNS 38Ca:  0 +- 0.062e-2
+delta_deltaNS 42Sc:  0 +- 0.061e-2
+delta_deltaNS 46V:   0 +- 0.065e-2
+delta_deltaNS 50Mn:  0 +- 0.069e-2
+delta_deltaNS 54Co:  0 +- 0.074e-2
+delta_deltaNS 62Ga:  0 +- 0.080e-2
+delta_deltaNS 74Rb:  0 +- 0.089e-2
 f_n: 1.6887(1)  # Hardy & Towner
 deltaRp_n: 0.014902(2)
 Lambda->p f_1(0): -1.2247 ± 0.05  # -sqrt(3/2) +-  "few percent"

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -554,6 +554,7 @@ PDFmembers avg=0 replicas=1-100:
 # Parameter for Bs->K*0mumu uncertainty inside resonant regions
 # 2209.04457, appendix B, Eq. B7, we save a relative uncertainty
 delta_BsKstarmumu: 0 ± 0.078
+
 # Updated EM corrections for Ke3 decays
 # From 2103.04843 (Table VI) 
 # Uncertainties combined in quadrature, factor of 2 normalisation difference since

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -525,21 +525,10 @@ DeltaRV: 0.02467(27)  # Average from 2208.11707
 # one third of the Z^2alpha^3 term in table V of 0710.3181,
 # as suggested in 1411.5987
 delta_deltaRp_Z2: 0 ± 0.00004e-2
-# Systematic errors on delta_NS from table XI of Hardy:2020qwl
-delta_deltaNS 10C:   0 +- 0.036e-2
-delta_deltaNS 14O:   0 +- 0.040e-2
-delta_deltaNS 22Mg:  0 +- 0.046e-2
-delta_deltaNS 26mAl: 0 +- 0.047e-2
-delta_deltaNS 34Cl:  0 +- 0.055e-2
-delta_deltaNS 34Ar:  0 +- 0.058e-2
-delta_deltaNS 38mK:  0 +- 0.058e-2
-delta_deltaNS 38Ca:  0 +- 0.062e-2
-delta_deltaNS 42Sc:  0 +- 0.061e-2
-delta_deltaNS 46V:   0 +- 0.065e-2
-delta_deltaNS 50Mn:  0 +- 0.069e-2
-delta_deltaNS 54Co:  0 +- 0.074e-2
-delta_deltaNS 62Ga:  0 +- 0.080e-2
-delta_deltaNS 74Rb:  0 +- 0.089e-2
+# Systematic uncertainty on delta_NS,A (eq. 16 of Hardy:2020qwl)
+delta_deltaNS,A: 0 +- 0.033e-2
+# Systematic uncertainty on delta_NS,E (eq. 18 of Hardy:2020qwl)
+delta_deltaNS,E: 0 +- 0.008e-2
 f_n: 1.6887(1)  # Hardy & Towner
 deltaRp_n: 0.014902(2)
 Lambda->p f_1(0): -1.2247 ± 0.05  # -sqrt(3/2) +-  "few percent"

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -528,7 +528,7 @@ delta_deltaRp_Z2: 0 ± 0.00004e-2
 # Systematic uncertainty on delta_NS,A (eq. 16 of Hardy:2020qwl)
 delta_deltaNS,A: 0 +- 0.033e-2
 # Systematic uncertainty on delta_NS,E (eq. 18 of Hardy:2020qwl)
-delta_deltaNS,E: 0 +- 0.008e-2
+delta_deltaNS,E_QEC: 0 +- 0.008e-2
 f_n: 1.6887(1)  # Hardy & Towner
 deltaRp_n: 0.014902(2)
 Lambda->p f_1(0): -1.2247 ± 0.05  # -sqrt(3/2) +-  "few percent"

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -226,8 +226,7 @@ def Ft_superallowed(par, wc_obj, A):
     ddNS_A = par[f'delta_deltaNS,A'] # systematic uncertainty on \delta_NS,A
     # systematic uncertainty on \delta_NS,E for a specific decay
     ddNS_E = par['delta_deltaNS,E'] * Q_EC[A]
-    ddNS = sqrt(ddNS_A**2 + ddNS_E**2)
-    return (1 + ddRp + ddNS) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
+    return (1 + ddRp + ddNS_A + ddNS_E) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
 
 
 class NeutronObservable:

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -203,7 +203,9 @@ def Ft_superallowed(par, wc_obj, A):
     GF = GFeff(wc_obj, par)
     pre = GF / sqrt(2) * Vud
     ddRp = par['delta_deltaRp_Z2'] * Z**2  # relative uncertainty on \delta R' (universal)
-    return (1 + ddRp) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
+    ddNS = par[f'delta_deltaNS {A}'] # systematic uncertainty on \delta_NS for specific decay
+    return (1 + ddRp + ddNS) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
+    # return (1 + ddRp) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
 
 
 class NeutronObservable:

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -225,7 +225,7 @@ def Ft_superallowed(par, wc_obj, A):
     ddRp = par['delta_deltaRp_Z2'] * Z**2  # relative uncertainty on \delta R' (universal)
     ddNS_A = par[f'delta_deltaNS,A'] # systematic uncertainty on \delta_NS,A
     # systematic uncertainty on \delta_NS,E for a specific decay
-    ddNS_E = par['delta_deltaNS,E'] * Q_EC[A]
+    ddNS_E = par['delta_deltaNS,E_QEC'] * Q_EC[A]
     return (1 + ddRp + ddNS_A + ddNS_E) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
 
 

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -189,6 +189,25 @@ nuclei_superallowed = {
 }
 
 
+# Transition energies in MeV (Table I of Hardy:2020qwl)
+Q_EC = {
+"10C":   1907.994e-3,
+"14O":   2831.543e-3,
+"22Mg":  4124.49e-3,
+"26mAl": 4232.72e-3,
+"34Cl":  5491.662e-3,
+"34Ar":  6061.83e-3,
+"38mK":  6044.240e-3,
+"38Ca":  6612.12e-3,
+"42Sc":  6426.34e-3,
+"46V":   7052.45e-3,
+"50Mn":  7634.453e-3,
+"54Co":  8244.38e-3,
+"62Ga":  9181.07e-3,
+"74Rb":  10416.8e-3,
+}
+
+
 def Ft_superallowed(par, wc_obj, A):
     r"""Corrected $\mathcal{F}t$ value of the beta decay of isotope `A`."""
     MF = sqrt(2)
@@ -203,7 +222,10 @@ def Ft_superallowed(par, wc_obj, A):
     GF = GFeff(wc_obj, par)
     pre = GF / sqrt(2) * Vud
     ddRp = par['delta_deltaRp_Z2'] * Z**2  # relative uncertainty on \delta R' (universal)
-    ddNS = par[f'delta_deltaNS {A}'] # systematic uncertainty on \delta_NS for specific decay
+    ddNS_A = par[f'delta_deltaNS,A'] # systematic uncertainty on \delta_NS,A
+    # # systematic uncertainty on \delta_NS,E for a specific decay
+    ddNS_E = par['delta_deltaNS,E'] * Q_EC[A]
+    ddNS = sqrt(ddNS_A**2 + ddNS_E**2)
     return (1 + ddRp + ddNS) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
 
 

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -205,7 +205,6 @@ def Ft_superallowed(par, wc_obj, A):
     ddRp = par['delta_deltaRp_Z2'] * Z**2  # relative uncertainty on \delta R' (universal)
     ddNS = par[f'delta_deltaNS {A}'] # systematic uncertainty on \delta_NS for specific decay
     return (1 + ddRp + ddNS) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
-    # return (1 + ddRp) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2
 
 
 class NeutronObservable:

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -190,6 +190,7 @@ nuclei_superallowed = {
 
 
 # Transition energies in MeV (Table I of Hardy:2020qwl)
+# Used for the calculation of the deltaNS uncertainties
 Q_EC = {
 "10C":   1907.994e-3,
 "14O":   2831.543e-3,

--- a/flavio/physics/betadecays/ft.py
+++ b/flavio/physics/betadecays/ft.py
@@ -224,7 +224,7 @@ def Ft_superallowed(par, wc_obj, A):
     pre = GF / sqrt(2) * Vud
     ddRp = par['delta_deltaRp_Z2'] * Z**2  # relative uncertainty on \delta R' (universal)
     ddNS_A = par[f'delta_deltaNS,A'] # systematic uncertainty on \delta_NS,A
-    # # systematic uncertainty on \delta_NS,E for a specific decay
+    # systematic uncertainty on \delta_NS,E for a specific decay
     ddNS_E = par['delta_deltaNS,E'] * Q_EC[A]
     ddNS = sqrt(ddNS_A**2 + ddNS_E**2)
     return (1 + ddRp + ddNS) * K(par) / Xi * 1 / (1 + B * me_E) / abs(pre)**2


### PR DESCRIPTION
This adds the enlarged uncertainties from recent developments (see III.A.3 of Hardy:2020qwl for some background) to the super-allowed beta decays.
In Hardy:2020qwl (and everyone else I think), the new developments are applied as a extra fixed systematic uncertainty on the Ft values, as with the delta_R' uncertainties, and so I have included them here in a similar way.
I've split it into `delta_NS,A` and `delta_NS,E` (matching the naming in Hardy&Towner (note delta_NS,B is already included as a statistical uncertainty)).
`delta_NS,A` is the same for each nucleus, while `delta_NS,E` is given as a fixed number multiplied by the decay transition energy `Q_EC`. 
I have checked that my implementation:
1. Gives a very similar size for the combined NS uncertainties for each nucleus as using the method of Hardy&Towner
1. Gives the same size discrepancy between Vud from beta decays and Vus from kaon decays as found in the literature (such as 2208.11707) and doing a naive chi2 fit.

(I've marked this as a draft since right now my branch is based upon some of various changes from my other pull requests, and so may need rebasing anyway once those are merged, and at that point it will be clearer what this one actually changes. But at least now I am less likely to forget it.)