### PR TITLE
fix B->D and B->D* HQET form factors

### DIFF
--- a/flavio/physics/bdecays/formfactors/b_v/cln.py
+++ b/flavio/physics/bdecays/formfactors/b_v/cln.py
@@ -4,6 +4,7 @@ from flavio.physics.bdecays.formfactors import hqet
 from flavio.physics.bdecays.formfactors import common
 from flavio.classes import AuxiliaryQuantity
 from flavio.physics.running import running
+from flavio.physics.common import lambda_K
 
 process_dict = {}
 process_dict['B->D*'] = {'B': 'B0', 'V': 'D*+', 'q': 'b->c'}
@@ -34,9 +35,8 @@ def h_to_A(mB, mV, h, q2):
     del ff['A2']
     # conversion from T_2, T_3 to T_23
     ff['T23'] = ((mB**2 - mV**2) * (mB**2 + 3 * mV**2 - q2) * ff['T2']
-                 - (mB**4 + (mV**2 - q2)**2
-                 - 2 * mB**2 * (mV**2 + q2)) * ff['T3']
-                 ) / (8 * mB * (mB - mV) * mV**2)
+                 - lambda_K(mB**2, mV**2, q2) * ff['T3']
+                ) / (8 * mB * (mB - mV) * mV**2)
     del ff['T3']
     return ff
 
@@ -81,7 +81,9 @@ def ff(process, q2, par, scale, order_z=3, order_z_slp=2, order_z_sslp=1):
                     + epsc * (L[2] - L[5] * (w - 1)/(w + 1))
                     + epsb * (L[1] - L[4] * (w - 1)/(w + 1))
                     + epsc**2 * (ell[2] - ell[5] * (w - 1)/(w + 1)))
-    h['A2'] = xi * (ash * CA2 + epsc * (L[3] + L[6]))
+    h['A2'] = xi * (ash * CA2
+                    + epsc * (L[3] + L[6])
+                    + epsc**2 * (ell[3] + ell[6]))
     h['A3'] = xi * (1 + ash * (CA1 + CA3)
                     + epsc * (L[2] - L[3] + L[6] - L[5])
                     + epsb * (L[1] - L[4])
@@ -93,8 +95,8 @@ def ff(process, q2, par, scale, order_z=3, order_z_slp=2, order_z_sslp=1):
     h['T2'] = xi * (ash * (w + 1)/2 * (CT2 + CT3)
                     + epsc * L[5]
                     - epsb * L[4]
-                    + epsc * ell[5])
+                    + epsc**2 * ell[5])
     h['T3'] = xi * (ash * CT2
                     + epsc * (L[6] - L[3])
-                    + epsc * (ell[6] - ell[3]))
+                    + epsc**2 * (ell[6] - ell[3]))
     return h_to_A(mB, mV, h, q2)

--- a/flavio/physics/bdecays/formfactors/hqet.py
+++ b/flavio/physics/bdecays/formfactors/hqet.py
@@ -8,16 +8,18 @@ from flavio.physics.bdecays.formfactors import common
 
 
 def get_hqet_parameters(par):
+    # use value from EOS fit of arXiv:1908.09398
+    # https://github.com/eos/eos/blob/417d909b35f7eac3b1ac7b6a552ff68aa20ff41d/eos/form-factors/mesonic-hqet.hh#L185-L191
     p = {}
-    # The scale here is fixed to 2.7 GeV ~ sqrt(m_b^pole * m_c^pole)
-    alphas = running.get_alpha(par, scale=2.7, nf_out=5)['alpha_s']
+    alphas = 0.26
     p['ash'] = alphas / pi
-    p['mb1S'] = running.get_mb_1S(par)
+    p['mb1S'] = 4.71
     p['mb'] = p['mb1S'] * (1 + 2 * alphas**2 / 9)
     p['mc'] = p['mb'] - 3.4
-    mBbar = (par['m_B0'] + 3 * par['m_B*0']) / 4
+    mBbar = 5.313
     # eq. (25); note the comment about the renormalon cancellation thereafter
-    p['Lambdabar'] = mBbar - p['mb'] + par['lambda_1'] / (2 * p['mb1S'])
+    lambda_1 = -0.3
+    p['Lambdabar'] = mBbar - p['mb'] + lambda_1 / (2 * p['mb1S'])
     p['epsc'] = p['Lambdabar'] / (2 * p['mc'])
     p['epsb'] = p['Lambdabar'] / (2 * p['mb'])
     p['zc'] = p['mc'] / p['mb']
@@ -25,9 +27,9 @@ def get_hqet_parameters(par):
 
 def xi(z, rho2, c, xi3, order_z):
     r"""Leading-order Isgur-Wise function:
-    
+
     $$\xi(z)=1-\rho^2 (w-1) + c (w-1)^2 + \xi^{(3)} (w-1)^3/6
-    
+
     where w=w(z) is expanded in $z$ up to an including terms of order
     `z**order_z`.
     """


### PR DESCRIPTION
This PR addresses issue #156 by fixing the HQET parameters used for the $B\to D^{(*)}$ form factors from [arXiv:1908.09398](https://arxiv.org/abs/1908.09398) as [defined in EOS](https://github.com/eos/eos/blob/417d909b35f7eac3b1ac7b6a552ff68aa20ff41d/eos/form-factors/mesonic-hqet.hh#L185-L191).