### PR TITLE
CAA related updates

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -4181,6 +4181,31 @@ PDG 2015:
     BR(K+->pienu): (5.07±0.04)1e-2
     Gamma(pi+->munu): (2.52809±0.00050)1e-17
 
+PDG 2022:
+  experiment: PDG
+  inspire: ParticleDataGroup:2022pth
+  values:
+    BR(pi+->enu): (1.230±0.004)1e-4
+    BR(K+->munu): (63.56±0.11)1e-2
+    Remu(K+->lnu): 2.488±0.009e-5
+    BR(KL->pimunu): (27.04±0.07)1e-2
+    BR(KL->pienu): (40.55±0.11)1e-2
+    BR(K+->pimunu): (3.352±0.033)1e-2
+    BR(K+->pienu): (5.07±0.04)1e-2
+    Gamma(pi+->munu): (2.52809±0.00050)1e-17
+
+KLOE-2 KS->pimunu 2019:
+  experiment: KLOE-2
+  inspire: KLOE-2:2019rev
+  values:
+    BR(KS->pimunu): (4.56±0.20)1e-4
+
+KLOE-2 KS->pienu 2022:
+  experiment: KLOE-2
+  inspire: KLOE-2:2022dot
+  values:
+    BR(KS->pienu): (7.153±0.057)1e-4
+
 PiENu pi->enu 2015:
   experiment: PiENu
   inspire: Aguilar-Arevalo:2015cdf
@@ -12239,6 +12264,28 @@ PDG 2018 D->Plnu:
     BR(D+->Kenu): (8.73 ± 0.10) 1e-2
     BR(D+->Kmunu): (8.74 ± 0.19) 1e-2
 
+PDG 2022 D->lnu:
+  inspire: ParticleDataGroup:2022pth
+  values:
+    BR(D+->enu): < 8.8e-6 @ 90% CL
+    BR(D+->munu): (3.74 ± 0.17) 1e-4
+    BR(D+->taunu): (1.20 ± 0.27) 1e-3
+    BR(Ds->enu): < 8.3e-5 @ 90% CL
+    BR(Ds->munu): (5.43 ± 0.15) 1e-3
+    BR(Ds->taunu): (5.32 ± 0.11) 1e-2
+
+PDG 2022 D->Plnu:
+  inspire: ParticleDataGroup:2022pth
+  values:
+    BR(D0->pienu): (2.91 ± 0.04) 1e-3
+    BR(D0->pimunu): (2.67 ± 0.12) 1e-3
+    BR(D0->Kenu): (3.549 ± 0.026) 1e-2
+    BR(D0->Kmunu): (3.41 ± 0.04) 1e-2
+    BR(D+->pienu): (3.72 ± 0.17) 1e-3
+    BR(D+->pimunu): (3.50 ± 0.15) 1e-3
+    BR(D+->Kenu): (8.72 ± 0.09) 1e-2
+    BR(D+->Kmunu): (8.76 ± 0.19) 1e-2
+    
 BESIII D0->Kenu 2015:
   observables:
   - name: <BR>(D0->Kenu)

--- a/flavio/data/parameters_correlated.yml
+++ b/flavio/data/parameters_correlated.yml
@@ -35,15 +35,16 @@
 # https://gist.github.com/DavidMStraub/813bd0c4296837936a188a29c8d8b981
 -
   values:
-    - f_K+: 0.1554(10)  # reproduce f_K/f_pi=1.1932(19) from FLAG 2019 Nf=2+1+1
+    - f_K+: 0.1554(10)  # reproduce f_K/f_pi=1.1932(21) from FLAG 2021 Nf=2+1+1
     - f_K0: 0.1554(10)
-    - f_pi+: 0.1302(8)  # FLAG 2019 Nf=2+1
+    - f_pi+: 0.1302(8)  # FLAG 2021 Nf=2+1
     - f_pi0: 0.1302(8)
   correlation:
-    [[1, 0.99, 0.968, 0.968],
-     [0.99, 1, 0.968, 0.968],
-     [0.968, 0.968, 1, 0.99],
-     [0.968, 0.968, 0.99, 1]]
+    [[1, 0.99, 0.961, 0.961],
+     [0.99, 1, 0.961, 0.961],
+     [0.961, 0.961, 1, 0.99],
+     [0.961, 0.961, 0.99, 1]]
+
 -
   values:
     - f_perp_K*+: 0.145(6)  # 1503.05534v2 table 1, but at 2 GeV
@@ -392,14 +393,14 @@
 
 # Electromagnetic corrections in Kl3 decays
 # 1005.2323 table 1 & eq. 18
+# Set just the Kmu3 parameters here, as we use 
+# updated Ke3 values (but without correlations)
 -
   values:
-    - K0e3 delta_EM: 0.495(110)1e-2
-    - K+e3 delta_EM: 0.050(125)1e-2
     - K0mu3 delta_EM: 0.700(110)1e-2
     - K+mu3 delta_EM: 0.008(125)1e-2
   correlation:
-    [[1, 0.081, 0.685, -0.147], [1, -0.147, 0.764], [1, 0.081], [1]]
+    [[1, 0.081], [1]]
 
 
 # Parameters for HQET form factors

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -234,10 +234,10 @@ c4_pi+munu: 1.69(0.07)
 c2t_pi+lnu: 0
 
 # Parameters needed for K->pi form factors
-K->pi f+(0): 0.9696(15)(12)        # 1809.02827
+K->pi f+(0): 0.9698(17)            # FLAG 2021 Nf=2+1+1 average
 K->pi fT(0): 0.417(15)             # 1108.1021
 K->pi sT: 1.10(14)                 #  "
-K->pi delta_K+pi0: 0.029(4)        # 1005.2323
+K->pi delta_K+pi0: 0.0252(11)      # 2208.11707, in text of sec. 2
 K->pi ln(C): 0.1998(138)           # 1602.04113
 K->pi Lambda_+: 24.22(1.16) 1e-3   #  "
 K->pi D: 0.0209(21)                # 0903.1654 table 1
@@ -521,7 +521,7 @@ CLN lp_5(1): 0
 CLN lp_6(1): 0
 
 # Parameters for beta decays
-DeltaRV: 0.02361(38)  # Marciano/Sirlin, arXiv:hep-ph/0510099
+DeltaRV: 0.02467(27)  # Average from 2208.11707
 # one third of the Z^2alpha^3 term in table V of 0710.3181,
 # as suggested in 1411.5987
 delta_deltaRp_Z2: 0 ± 0.00004e-2
@@ -554,3 +554,9 @@ PDFmembers avg=0 replicas=1-100:
 # Parameter for Bs->K*0mumu uncertainty inside resonant regions
 # 2209.04457, appendix B, Eq. B7, we save a relative uncertainty
 delta_BsKstarmumu: 0 ± 0.078
+# Updated EM corrections for Ke3 decays
+# From 2103.04843 (Table VI) 
+# Uncertainties combined in quadrature, factor of 2 normalisation difference since
+# flavio used the normalisation of 1005.2323
+K0e3 delta_EM: 0.580(16)1e-2
+K+e3 delta_EM: 0.105(24)1e-2


### PR DESCRIPTION
This is just the CAA related measurement updates from #196. 
This is most of the new inputs I made use of in my paper on the CAA (https://arxiv.org/abs/2212.06862)
For KS->pi mu nu and KS->pi e nu, I removed the PDG values from the group and added them separately, since:
1. For e the old PDG number was dominated by a 2006 KLOE measurement and the new result is actually a combination of that with the new data.
1. For mu, the only measurement is the 2019 result from KLOE (the old number was, to quote the PDG, "not a measurement, calculate as 0.666 x BR(pi e nu)")