### PR TITLE
Angular observables in B0->D*lnu

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -22430,3 +22430,68 @@ LHCb Bs->K*mumu 2018:
    inspire: LHCb:2018rym
    values:
      BR_LHCb(Bs->K*0mumu): 2.9 ± 1.0 ± 0.2 ± 0.3 1e-8
+
+Belle-II B0->D*lnu angular 2023:
+  inspire: Belle-II:2023kkm
+  experiment: Belle-II
+  values:
+    - name: <Dmue_AFB>(B0->D*lnu)
+      q2min: 4.85
+      q2max: 10.689
+      value: 0.099 ± 0.056 ± 0.020
+    - name: <Dmue_AFB>(B0->D*lnu)
+      q2min: 0
+      q2max: 4.85
+      value: -0.168 ± 0.068 ± 0.024
+    - name: <Dmue_AFB>(B0->D*lnu)
+      q2min: 0
+      q2max: 10.689
+      value: -0.024 ± 0.043 ± 0.016
+    - name: <Dmue_S3>(B0->D*lnu)
+      q2min: 4.85
+      q2max: 10.689
+      value: -0.026 ± 0.068 ± 0.024
+    - name: <Dmue_S3>(B0->D*lnu)
+      q2min: 0
+      q2max: 4.85
+      value: -0.101 ± 0.069 ± 0.025
+    - name: <Dmue_S3>(B0->D*lnu)
+      q2min: 0
+      q2max: 10.689
+      value: -0.062 ± 0.047 ± 0.017
+    - name: <Dmue_S5>(B0->D*lnu)
+      q2min: 4.85
+      q2max: 10.689
+      value: -0.019 ± 0.068 ± 0.024
+    - name: <Dmue_S5>(B0->D*lnu)
+      q2min: 0
+      q2max: 4.85
+      value: -0.055 ± 0.065 ± 0.023
+    - name: <Dmue_S5>(B0->D*lnu)
+      q2min: 0
+      q2max: 10.689
+      value: -0.035 ± 0.046 ± 0.016
+    - name: <Dmue_S7>(B0->D*lnu)
+      q2min: 4.85
+      q2max: 10.689
+      value: 0.028 ± 0.067 ± 0.024
+    - name: <Dmue_S7>(B0->D*lnu)
+      q2min: 0
+      q2max: 4.85
+      value: -0.066 ± 0.065 ± 0.022
+    - name: <Dmue_S7>(B0->D*lnu)
+      q2min: 0
+      q2max: 10.689
+      value: -0.026 ± 0.046 ± 0.016
+    - name: <Dmue_S9>(B0->D*lnu)
+      q2min: 4.85
+      q2max: 10.689
+      value: 0.032 ± 0.067 ± 0.024
+    - name: <Dmue_S9>(B0->D*lnu)
+      q2min: 0
+      q2max: 4.85
+      value: 0.020 ± 0.068 ± 0.024
+    - name: <Dmue_S9>(B0->D*lnu)
+      q2min: 0
+      q2max: 10.689
+      value: 0.020 ± 0.047 ± 0.017


### PR DESCRIPTION
Belle-II has recently published ([arXiv:2308.02023](https://arxiv.org/abs/2308.02023)) some angular measurements in $B^0\to D^{\*-} \mu^+ \bar{\nu}\_\mu$ and $B^0\to D^{\*-} e^+ \bar{\nu}\_e$ decays that were not implemented in *flavio*. 

We have adapted the code used to calculate the angular observables in $B\to V\ell^+\ell^-$. All the differential and binned observables are implemented for all the available processes ($B^0\to D^{\*-}$, $B^+\to D^{\*0}$, $B^0\to\rho^+$, $B^+\to\rho^0$, $B^+\to\omega$ and $B_s\to K^{\*-}$ and all three leptons). The LFU differences $D_{\mu e}$ are only implemented for the $B^0\to D^{\*-}$ process in the observables measured at Belle-II: $A_\mathrm{FB}$, $S_3$, $S_5$, $S_7$ and $S_9$, although we could extend it to other observables and processes if needed.