### PR TITLE
fix B->K(*)nunu and K->pinunu implementations

### DIFF
--- a/flavio/data/citations.yml
+++ b/flavio/data/citations.yml
@@ -38,6 +38,7 @@
 - Leljak:2021vte
 - Meinel:2020owd
 - Melikhov:2004mk
+- Mescia:2007kn
 - Misiak:2006ab
 - Misiak:2015xwa
 - Mott:2011cx

--- a/flavio/data/parameters_metadata.yml
+++ b/flavio/data/parameters_metadata.yml
@@ -21,6 +21,13 @@ Delta_alpha_e_lep:
   description: leptonic contribution to the running of the electromagnetic fine structure constant between 0 and $m_Z$
 
 
+# di->djnunu Wilson coefficient loop function
+
+Xt_di->djnunu:
+  tex: $X_t^{d_i\to d_j\nu\bar\nu}$
+  description: Loop function for the CL_SM Wilson coefficient of $d_i\to d_j\nu\bar\nu$
+
+
 # CKM parameters
 
 Vus:

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -34,7 +34,7 @@ Delta_alpha_e_lep: 0.0314977 # hep-ph/9803313 table 1
 
 # di->djnunu Wilson coefficient loop function
 
-Xt_di->djnunu: 1.462 ± 0.017 ± 0.002
+Xt_di->djnunu: 1.462 ± 0.017 ± 0.002 # 2105.02868 Eq. (5)
 
 # CKM parameters
 

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -32,6 +32,9 @@ s2w: 0.23121(4)       # PDG 2023 Review Sec. 1
 Delta_alpha_e_had: 0.027572 ± 0.000359 # hep-ph/0104304 page 5
 Delta_alpha_e_lep: 0.0314977 # hep-ph/9803313 table 1
 
+# di->djnunu Wilson coefficient loop function
+
+Xt_di->djnunu: 1.462 ± 0.017 ± 0.002
 
 # CKM parameters
 

--- a/flavio/physics/bdecays/bpnunu.py
+++ b/flavio/physics/bdecays/bpnunu.py
@@ -22,7 +22,12 @@ def helicity_amps(q2, wc_obj, par, B, P, nu1, nu2):
     label = flavio.physics.bdecays.common.meson_quark[(B,P)] + nu1 + nu2 # e.g. bsnuenue, bdnutaunumu
     wc = wc_obj.get_wc(label, scale, par)
     if nu1 == nu2: # add the SM contribution if neutrino flavours coincide
-        wc['CL_'+label] += flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
+        # CL_SM * alpha_e is scale invariant
+        CL_SM_MZ = flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
+        alpha_e_mu = flavio.physics.running.running.get_alpha(par, scale)['alpha_e']
+        alpha_e_mZ = flavio.physics.running.running.get_alpha(par, 91.1876)['alpha_e']
+        CL_SM_mu = CL_SM_MZ * alpha_e_mZ/alpha_e_mu
+        wc['CL_'+label] += CL_SM_mu
     mB = par['m_'+B]
     mP = par['m_'+P]
     N = prefactor(q2, par, B, P)

--- a/flavio/physics/bdecays/bpnunu.py
+++ b/flavio/physics/bdecays/bpnunu.py
@@ -22,12 +22,7 @@ def helicity_amps(q2, wc_obj, par, B, P, nu1, nu2):
     label = flavio.physics.bdecays.common.meson_quark[(B,P)] + nu1 + nu2 # e.g. bsnuenue, bdnutaunumu
     wc = wc_obj.get_wc(label, scale, par)
     if nu1 == nu2: # add the SM contribution if neutrino flavours coincide
-        # CL_SM * alpha_e is scale invariant
-        CL_SM_MZ = flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
-        alpha_e_mu = flavio.physics.running.running.get_alpha(par, scale)['alpha_e']
-        alpha_e_mZ = flavio.physics.running.running.get_alpha(par, 91.1876)['alpha_e']
-        CL_SM_mu = CL_SM_MZ * alpha_e_mZ/alpha_e_mu
-        wc['CL_'+label] += CL_SM_mu
+        wc['CL_'+label] += flavio.physics.bdecays.wilsoncoefficients.CL_SM(par, scale)
     mB = par['m_'+B]
     mP = par['m_'+P]
     N = prefactor(q2, par, B, P)

--- a/flavio/physics/bdecays/bvnunu.py
+++ b/flavio/physics/bdecays/bvnunu.py
@@ -23,12 +23,7 @@ def helicity_amps(q2, wc_obj, par, B, V, nu1, nu2):
     label = flavio.physics.bdecays.common.meson_quark[(B,V)] + nu1 + nu2 # e.g. bsnuenue, bdnutaunumu
     wc = wc_obj.get_wc(label, scale, par)
     if nu1 == nu2: # add the SM contribution if neutrino flavours coincide
-        # CL_SM * alpha_e is scale invariant
-        CL_SM_MZ = flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
-        alpha_e_mu = flavio.physics.running.running.get_alpha(par, scale)['alpha_e']
-        alpha_e_mZ = flavio.physics.running.running.get_alpha(par, 91.1876)['alpha_e']
-        CL_SM_mu = CL_SM_MZ * alpha_e_mZ/alpha_e_mu
-        wc['CL_'+label] += CL_SM_mu
+        wc['CL_'+label] += flavio.physics.bdecays.wilsoncoefficients.CL_SM(par, scale)
     mB = par['m_'+B]
     mV = par['m_'+V]
     N = prefactor(q2, par, B, V)

--- a/flavio/physics/bdecays/bvnunu.py
+++ b/flavio/physics/bdecays/bvnunu.py
@@ -23,7 +23,12 @@ def helicity_amps(q2, wc_obj, par, B, V, nu1, nu2):
     label = flavio.physics.bdecays.common.meson_quark[(B,V)] + nu1 + nu2 # e.g. bsnuenue, bdnutaunumu
     wc = wc_obj.get_wc(label, scale, par)
     if nu1 == nu2: # add the SM contribution if neutrino flavours coincide
-        wc['CL_'+label] += flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
+        # CL_SM * alpha_e is scale invariant
+        CL_SM_MZ = flavio.physics.bdecays.wilsoncoefficients.CL_SM(par)
+        alpha_e_mu = flavio.physics.running.running.get_alpha(par, scale)['alpha_e']
+        alpha_e_mZ = flavio.physics.running.running.get_alpha(par, 91.1876)['alpha_e']
+        CL_SM_mu = CL_SM_MZ * alpha_e_mZ/alpha_e_mu
+        wc['CL_'+label] += CL_SM_mu
     mB = par['m_'+B]
     mV = par['m_'+V]
     N = prefactor(q2, par, B, V)

--- a/flavio/physics/bdecays/test_wc.py
+++ b/flavio/physics/bdecays/test_wc.py
@@ -57,10 +57,6 @@ class TestBWilson(unittest.TestCase):
 
     def test_clnu(self):
         par_dict = flavio.default_parameters.get_central_all()
-        par_dict['alpha_s'] = 0.1184
-        par_dict['alpha_e'] = 1/127.925
-        par_dict['s2w']  = 0.2315
-        par_dict['m_t']  = 173.3
-        cl = wilsoncoefficients.CL_SM(par_dict)
-        # comparing the central value of X_t to (4.2) of 1009.0947
-        self.assertAlmostEqual(-cl*par_dict['s2w']/1.469, 1, delta=0.01)
+        cl = wilsoncoefficients.CL_SM(par_dict, scale=91.1876)
+        # comparing the central value of X_t to (5) of 2105.02868
+        self.assertAlmostEqual(-cl*par_dict['s2w']/1.462, 1, delta=0.001)

--- a/flavio/physics/bdecays/wilsoncoefficients.py
+++ b/flavio/physics/bdecays/wilsoncoefficients.py
@@ -34,18 +34,20 @@ def CL_SM(par):
 
     This is implemented as an approximate formula as a function of the top
     mass."""
-    # EW NLO corrections arXiv:1009.0947
-    scale = 120. # <- result has very little sensitivity to high matching scale
-    mt = flavio.physics.running.running.get_mt(par, scale)
+    # # EW NLO corrections arXiv:1009.0947
+    # scale = 120. # <- result has very little sensitivity to high matching scale
+    # mt = flavio.physics.running.running.get_mt(par, scale)
+    # Xt0_165 = 1.50546 # LO result for mt=165, scale=120
+    # Xt0 = Xt0_165 * (1 + 1.14064 * (mt/165. - 1)) # LO
+    # Xt1 = Xt0_165 * (-0.031435 - 0.139303 * (mt/165. - 1)) # QCD NLO
+    # # (4.3), (4.4) of 1009.0947: NLO EW
+    # flavio.citations.register("Brod:2010hi")
+    # XtEW = Xt0 * (1 - 1.11508 + 1.12316*1.15338**(mt/165.)-0.179454*(mt/165)) - 1
+    # XtEW = XtEW * 0.00062392534457616328 # <- alpha_em/4pi at 120 GeV
+    # Xt = Xt0 + Xt1 + XtEW
+
     s2w = par['s2w']
-    Xt0_165 = 1.50546 # LO result for mt=165, scale=120
-    Xt0 = Xt0_165 * (1 + 1.14064 * (mt/165. - 1)) # LO
-    Xt1 = Xt0_165 * (-0.031435 - 0.139303 * (mt/165. - 1)) # QCD NLO
-    # (4.3), (4.4) of 1009.0947: NLO EW
-    flavio.citations.register("Brod:2010hi")
-    XtEW = Xt0 * (1 - 1.11508 + 1.12316*1.15338**(mt/165.)-0.179454*(mt/165)) - 1
-    XtEW = XtEW * 0.00062392534457616328 # <- alpha_em/4pi at 120 GeV
-    Xt = Xt0 + Xt1 + XtEW
+    Xt = par['Xt_di->djnunu']
     return -Xt/s2w
 
 

--- a/flavio/physics/bdecays/wilsoncoefficients.py
+++ b/flavio/physics/bdecays/wilsoncoefficients.py
@@ -29,7 +29,7 @@ data = np.load(pkg_resources.resource_filename('flavio.physics', 'data/wcsm/wc_s
 wcsm_nf5 = scipy.interpolate.interp1d(scales, data)
 
 # di->djnunu Wilson coefficient
-def CL_SM(par):
+def CL_SM(par, scale):
     r"""SM Wilson coefficient for $d_i\to d_j\nu\bar\nu$ transitions.
 
     This is implemented as an approximate formula as a function of the top
@@ -48,7 +48,11 @@ def CL_SM(par):
 
     s2w = par['s2w']
     Xt = par['Xt_di->djnunu']
-    return -Xt/s2w
+    CL_SM = -Xt/s2w
+    # CL_SM * alpha_e is scale invariant
+    alpha_e_scale = flavio.physics.running.running.get_alpha(par, scale)['alpha_e']
+    alpha_e_mZ = flavio.physics.running.running.get_alpha(par, 91.1876)['alpha_e']
+    return CL_SM * alpha_e_mZ/alpha_e_scale
 
 
 # names of SM DeltaF=1 Wilson coefficients needed for wctot_dict


### PR DESCRIPTION
This PR fixes the following issues in the implementation of the `CL` Wilson coefficient used in $B\to K^{(\ast)}\nu\nu$ and  $K\to \pi^{(\ast)}\nu\nu$:
- `CL` is defined at $M_Z$. Since the product of `CL_SM * alpha_e` is scale invariant, `CL` at lower scales is determined from the running of `alpha_e`.
- The implementation of the `Xt` loop function that enters the SM prediction of `CL` did not take into account the remaining scale dependence in the NLO QCD result. As a temporary fix, it has been replaced by the parameter `Xt_di->djnunu` taken from [arXiv:2105.02868](https://arxiv.org/abs/2105.02868) Eq. (5). 