### PR TITLE
add BCL parameterization with t0=0

### DIFF
--- a/flavio/physics/bdecays/formfactors/b_p/bcl.py
+++ b/flavio/physics/bdecays/formfactors/b_p/bcl.py
@@ -42,6 +42,7 @@ def ff(process, q2, par, n=3, t0=None):
     m0 = par[process + ' BCL m0']
     mB = par['m_'+pd['B']]
     mP = par['m_'+pd['P']]
+    chL = par.get(process + ' BCL chL', 1) # chiral logarithm factor (arXiv:2207.12468)
     ff = {}
     a={}
     for i in ['f+', 'fT']:
@@ -59,9 +60,9 @@ def ff(process, q2, par, n=3, t0=None):
         an_f0 = (f0_q20-fplus_q20)/z(mB, mP, 0, t0)**(n-1)
         a['f0'].append(an_f0)
     # evaluate FFs
-    ff['f+'] = pole('f+', mpl, q2) * param_fplusT(mB, mP, a['f+'], q2, t0)
-    ff['fT'] = pole('fT', mpl, q2) * param_fplusT(mB, mP, a['fT'], q2, t0)
-    ff['f0'] = pole('f0', m0, q2) * param_f0(mB, mP, a['f0'], q2, t0)
+    ff['f+'] = chL * pole('f+', mpl, q2) * param_fplusT(mB, mP, a['f+'], q2, t0)
+    ff['fT'] = chL * pole('fT', mpl, q2) * param_fplusT(mB, mP, a['fT'], q2, t0)
+    ff['f0'] = chL * pole('f0', m0, q2) * param_f0(mB, mP, a['f0'], q2, t0)
     return ff
 
 def ff_isgurwise(process, q2, par, scale, n=3, t0=None):

--- a/flavio/physics/bdecays/formfactors/b_p/bcl.py
+++ b/flavio/physics/bdecays/formfactors/b_p/bcl.py
@@ -46,13 +46,18 @@ def ff(process, q2, par, n=3, t0=None):
     a={}
     for i in ['f+', 'fT']:
         a[i] = [ par[process + ' BCL' + ' a' + str(j) + '_' + i] for j in range(n) ]
-    # only the first n-1 parameters for f0 are taken from par
-    # the nth one is chosen to fulfill the kinematic constraint f+(0)=f0(0)
-    a['f0'] = [ par[process + ' BCL' + ' a' + str(j) + '_f0'] for j in range(n-1) ]
-    fplus_q20 = pole('f+', mpl, 0) * param_fplusT(mB, mP, a['f+'], 0, t0)
-    f0_q20 = pole('f0', m0, 0) * param_f0(mB, mP, a['f0'], 0, t0)
-    an_f0 = (f0_q20-fplus_q20)/z(mB, mP, 0, t0)**(n-1)
-    a['f0'].append(an_f0)
+    if t0 == 0: # z(q^2=0) = 0
+        # if z(q^2=0) = 0, then the kinematic constraint f+(0)=f0(0) means
+        # a['f0'][0] = a['f+'][0]
+        a['f0'] = a['f+'][:1] + [ par[process + ' BCL' + ' a' + str(j) + '_f0'] for j in range(1,n) ]
+    else:
+        # only the first n-1 parameters for f0 are taken from par
+        # the nth one is chosen to fulfill the kinematic constraint f+(0)=f0(0)
+        a['f0'] = [ par[process + ' BCL' + ' a' + str(j) + '_f0'] for j in range(n-1) ]
+        fplus_q20 = pole('f+', mpl, 0) * param_fplusT(mB, mP, a['f+'], 0, t0)
+        f0_q20 = pole('f0', m0, 0) * param_f0(mB, mP, a['f0'], 0, t0)
+        an_f0 = (f0_q20-fplus_q20)/z(mB, mP, 0, t0)**(n-1)
+        a['f0'].append(an_f0)
     # evaluate FFs
     ff['f+'] = pole('f+', mpl, q2) * param_fplusT(mB, mP, a['f+'], q2, t0)
     ff['fT'] = pole('fT', mpl, q2) * param_fplusT(mB, mP, a['fT'], q2, t0)

--- a/flavio/physics/bdecays/formfactors/b_p/btop.py
+++ b/flavio/physics/bdecays/formfactors/b_p/btop.py
@@ -25,6 +25,11 @@ for p in processes_H2L + processes_H2H:
                    function=ff_function(bcl.ff, p, n=3))
     i.set_description("3-parameter BCL parametrization (see arXiv:0807.2722).")
 
+    iname = p + ' BCL3 t0=0'
+    i = Implementation(name=iname, quantity=quantity,
+                   function=ff_function(bcl.ff, p, n=3, t0=0))
+    i.set_description("3-parameter BCL parametrization with t0=0 (e.g. arXiv:2207.12468).")
+
     iname = p + ' BCL4'
     i = Implementation(name=iname, quantity=quantity,
                    function=ff_function(bcl.ff, p, n=4))


### PR DESCRIPTION
If the $z$-parameterization is defined with $t_0=0$, then $z(q^2=0)=0$ and the kinematic constraint f+(0)=f0(0) translates into $a_0^0=a_0^+$. This special case has not been covered by the BCL implementation so far, which is fixed in this PR.
In addition, an optional chiral logarithm factor (as e.g. used in [arXiv:2207.12468](https://arxiv.org/abs/2207.12468)) is introduced.