### PR TITLE
fix gkvd masses

### DIFF
--- a/flavio/physics/bdecays/formfactors/b_p/bsz_parameters.py
+++ b/flavio/physics/bdecays/formfactors/b_p/bsz_parameters.py
@@ -58,7 +58,7 @@ def load_parameters(filename, process, constraints):
 resonance_masses_gkvd = {
     'B->K': {
         'm0': 5.630,
-        'm+': 5.412,
+        'm+': 5.415,
     },
     'B->pi': {
         'm0': 5.540,


### PR DESCRIPTION
The PR fixes the values of the resonance masses used in the GKVD form factors from [arXiv:1811.00983](https://arxiv.org/abs/1811.00983). The table 5 of [arXiv:1811.00983](https://arxiv.org/abs/1811.00983) contains some typos and the actual masses used are those implemented in EOS, in particular `m+` for $B\to K$ can be found at https://github.com/eos/eos/blob/63d6de2b70b396f9705166e3d9e71ad21b48e26e/eos/parameters/hadronic-matrix-elements.yaml#L182-L187