### PR TITLE
update and improve `error_budget_pie` function

### DIFF
--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -32,7 +32,7 @@ def error_budget_pie(err_dict, other_cutoff=0.03):
     squared total error is smaller than this number, it is lumped under "other".
     Defaults to 0.03.
     """
-    var_tot = np.sum(np.array(list(err_dict.values()))**2) # total variance from sum of squared individual errors
+    var_tot = sum(v**2 for v in err_dict.values()) # total variance from sum of squared individual errors
     err_dict_sorted = OrderedDict(sorted(err_dict.items(), key=lambda t: -t[1]))
     labels = []
     fracs = []

--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -54,7 +54,7 @@ def error_budget_pie(err_dict, other_cutoff=0.03):
             small_frac.append(frac)
     if small_frac:
         labels.append('other')
-        fracs.append(np.sum(small_frac))
+        fracs.append(sum(small_frac))
     def my_autopct(pct):
         # use individual errors as labels
         return r'{p:.2g}\%'.format(p=np.sqrt(100*pct*var_tot))


### PR DESCRIPTION
Previously, the `error_budget_pie` function was representing the individual errors as fractions of a linearly summed total error. Such a representation can be rather misleading since the actual total error corresponds to the individual errors summed in quadrature, not linearly.

This PR updates the `error_budget_pie` function to improve the visual representation of the individual error contributions. In the new version
- the wedges are labelled with the actual relative error contributions (not as the fractions of the linearly summed total error as before),
- the area of each wedge is proportional to the squared error contribution such that the total area of the pie corresponds to the actual squared total error.

So the new version gives an accurate graphical representation of the individual errors summed in quadrature and the sizes of the wedges have an intuitive interpretation in terms of the individual variance contributions that can be summed linearly. Furthermore, the numbers on the labels now exactly correspond to the results of `flavio.sm_error_budget`, also when small contributions are grouped together under "other" (this was not the case before since "other" always corresponded to small errors summed in quadrature), and summing all the numbers on the labels in quadrature now exactly yields the actual total error.