### PR TITLE
fix `diff_plot_th_err` function to correctly utilize argument `N`

### DIFF
--- a/flavio/plots/plotfunctions.py
+++ b/flavio/plots/plotfunctions.py
@@ -146,10 +146,10 @@ def diff_plot_th_err(obs_name, x_min, x_max, wc=None, steps=100,
     x_err_arr[-1] = x_arr[-1]
     if wc is None:
         wc = flavio.physics.eft._wc_sm # SM Wilson coefficients
-        obs_err_arr = [flavio.sm_uncertainty(obs_name, x, threads=threads) for x in x_err_arr]
+        obs_err_arr = [flavio.sm_uncertainty(obs_name, x, N=N, threads=threads) for x in x_err_arr]
         obs_arr = [flavio.sm_prediction(obs_name, x) for x in x_arr]
     else:
-        obs_err_arr = [flavio.np_uncertainty(obs_name, wc, x, threads=threads) for x in x_err_arr]
+        obs_err_arr = [flavio.np_uncertainty(obs_name, wc, x, N=N, threads=threads) for x in x_err_arr]
         obs_arr = [flavio.np_prediction(obs_name, wc, x) for x in x_arr]
     ax = plt.gca()
     plot_args = plot_args or {}


### PR DESCRIPTION
Addressed a small issue in the function `diff_plot_th_err`, where the `N` parameter wasn't accessed for computing uncertainties. Previously, the functions `flavio.sm_uncertainty` and `flavio.sm_uncertainty` within `diff_plot_th_err` were not utilizing the provided `N` value, resulting in the default value (`N`=100) being used for all uncertainty calculations.