### PR TITLE
fix typo in LHCb RD* 2023

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -4971,11 +4971,11 @@ LHCb RD* 2017:
   values:
     Rtaumu(B->D*lnu): 0.291 ± 0.019 ± 0.026 ± 0.013
 
-LHCb RD* 2023:
+LHCb RD* 2023: #supersedes LHCb RD* 2017
   experiment: LHCb
   inspire: LHCb:2023cjr
   values:
-    Rtaumu(B->D*lnu): 0.247 ± 0.015 ± 0.015 ± 0.012
+    Rtaumu(B->D*lnu): 0.267 ± 0.012 ± 0.015 ± 0.013
 
 LHCb RD RD* 2022:
     experiment: LHCb


### PR DESCRIPTION
Update of LHCb RD* 2023. The initial commit corresponds to the first published result (https://arxiv.org/abs/2305.01463v1) which was updated in may 2024 (https://arxiv.org/abs/2305.01463v2).

This new value is a combination including the result of LHCb RD* 2017 (1708.08856)