### PR TITLE
added space in tex strings 

### DIFF
--- a/flavio/physics/quarkonium/Pll.py
+++ b/flavio/physics/quarkonium/Pll.py
@@ -69,8 +69,8 @@ def Pll_br_comb_func(P,  l1, l2):
 
 # Observable and Prediction instances
 _hadr = { 
-    'eta_c(1S)': {'tex': r"\eta_c(1S)\to", 'P': 'eta_c(1S)' },
-    'eta_b(1S)': {'tex': r"\eta_b(1S)\to", 'P': 'eta_b(1S)' },
+    'eta_c(1S)': {'tex': r"\eta_c(1S)\to ", 'P': 'eta_c(1S)' },
+    'eta_b(1S)': {'tex': r"\eta_b(1S)\to ", 'P': 'eta_b(1S)' },
  }
 
 _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-', 

--- a/flavio/physics/quarkonium/Pll.py
+++ b/flavio/physics/quarkonium/Pll.py
@@ -83,7 +83,7 @@ _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-',
 
 
 def _define_obs_P_ll(M, ll):
-    _process_tex = _hadr[M]['tex']+_tex[''.join(ll)]
+    _process_tex = _hadr[M]['tex']+' '+_tex[''.join(ll)]
     _process_taxonomy = r'Process :: quarkonium lepton decays :: $P\to \ell^+\ell^-$ :: $' + _process_tex + r"$"
     _obs_name = "BR("+_hadr[M]['P']+"->"+''.join(ll)+")"
     _obs = Observable(_obs_name,arguments=["CeGGij","CeGGji"])

--- a/flavio/physics/quarkonium/Pll.py
+++ b/flavio/physics/quarkonium/Pll.py
@@ -83,7 +83,7 @@ _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-',
 
 
 def _define_obs_P_ll(M, ll):
-    _process_tex = _hadr[M]['tex']+' '+_tex[''.join(ll)]
+    _process_tex = _hadr[M]['tex']+_tex[''.join(ll)]
     _process_taxonomy = r'Process :: quarkonium lepton decays :: $P\to \ell^+\ell^-$ :: $' + _process_tex + r"$"
     _obs_name = "BR("+_hadr[M]['P']+"->"+''.join(ll)+")"
     _obs = Observable(_obs_name,arguments=["CeGGij","CeGGji"])

--- a/flavio/physics/quarkonium/Sll.py
+++ b/flavio/physics/quarkonium/Sll.py
@@ -76,7 +76,7 @@ _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-',
 
 
 def _define_obs_S_ll(M, ll):
-    _process_tex = _hadr[M]['tex']+_tex[''.join(ll)]
+    _process_tex = _hadr[M]['tex']+' '+_tex[''.join(ll)]
     _process_taxonomy = r'Process :: quarkonium lepton decays :: $S\to \ell^+\ell^-$ :: $' + _process_tex + r"$"
     _obs_name = "BR("+_hadr[M]['S']+"->"+''.join(ll)+")"
     _obs = Observable(_obs_name,arguments=["CeGGij","CeGGji"])

--- a/flavio/physics/quarkonium/Sll.py
+++ b/flavio/physics/quarkonium/Sll.py
@@ -61,9 +61,9 @@ def Sll_br_comb_func(S,  l1, l2):
 
 # Observable and Prediction instances
 _hadr = { 
-    'chi_c0(1P)': {'tex': r"\chi_{c0}(1P)\to", 'S': 'chi_c0(1P)', 'Q': 2./3., },
-    'chi_b0(1P)': {'tex': r"\chi_{b0}(1P)\to", 'S': 'chi_b0(1P)', 'Q': -1./3., },
-    'chi_b0(2P)': {'tex': r"\chi_{b0}(2P)\to", 'S': 'chi_b0(2P)', 'Q': -1./3., },
+    'chi_c0(1P)': {'tex': r"\chi_{c0}(1P)\to ", 'S': 'chi_c0(1P)', 'Q': 2./3., },
+    'chi_b0(1P)': {'tex': r"\chi_{b0}(1P)\to ", 'S': 'chi_b0(1P)', 'Q': -1./3., },
+    'chi_b0(2P)': {'tex': r"\chi_{b0}(2P)\to ", 'S': 'chi_b0(2P)', 'Q': -1./3., },
  }
 
 _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-', 

--- a/flavio/physics/quarkonium/Sll.py
+++ b/flavio/physics/quarkonium/Sll.py
@@ -76,7 +76,7 @@ _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-',
 
 
 def _define_obs_S_ll(M, ll):
-    _process_tex = _hadr[M]['tex']+' '+_tex[''.join(ll)]
+    _process_tex = _hadr[M]['tex']+_tex[''.join(ll)]
     _process_taxonomy = r'Process :: quarkonium lepton decays :: $S\to \ell^+\ell^-$ :: $' + _process_tex + r"$"
     _obs_name = "BR("+_hadr[M]['S']+"->"+''.join(ll)+")"
     _obs = Observable(_obs_name,arguments=["CeGGij","CeGGji"])

--- a/flavio/physics/quarkonium/Vll.py
+++ b/flavio/physics/quarkonium/Vll.py
@@ -123,11 +123,11 @@ def Vll_ratio_comb_func(V, Q, l1, l2):
 
 # Observable and Prediction instances
 _hadr = { 
-    'J/psi': {'tex': r"J/\psi\to", 'V': 'J/psi', 'Q': 2./3., },
-    'psi(2S)': {'tex': r"\psi(2S)\to", 'V': 'psi(2S)', 'Q': 2./3., }, 
-    'Upsilon(1S)': {'tex': r"\Upsilon(1S)\to", 'V': 'Upsilon(1S)', 'Q': -1./3., },
-    'Upsilon(2S)': {'tex': r"\Upsilon(2S)\to", 'V': 'Upsilon(2S)', 'Q': -1./3., },
-    'Upsilon(3S)': {'tex': r"\Upsilon(3S)\to", 'V': 'Upsilon(3S)', 'Q': -1./3., },
+    'J/psi': {'tex': r"J/\psi\to ", 'V': 'J/psi', 'Q': 2./3., },
+    'psi(2S)': {'tex': r"\psi(2S)\to ", 'V': 'psi(2S)', 'Q': 2./3., }, 
+    'Upsilon(1S)': {'tex': r"\Upsilon(1S)\to ", 'V': 'Upsilon(1S)', 'Q': -1./3., },
+    'Upsilon(2S)': {'tex': r"\Upsilon(2S)\to ", 'V': 'Upsilon(2S)', 'Q': -1./3., },
+    'Upsilon(3S)': {'tex': r"\Upsilon(3S)\to ", 'V': 'Upsilon(3S)', 'Q': -1./3., },
  }
 
 _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-', 

--- a/flavio/physics/quarkonium/Vllgamma.py
+++ b/flavio/physics/quarkonium/Vllgamma.py
@@ -162,10 +162,10 @@ def Vllgamma_ratio_comb_func(V, Q, l1, l2):
 # Observable and Prediction instances
 _hadr = { 
     'J/psi': {'tex': r"J/\psi\to", 'V': 'J/psi', 'Q': 2./3., },
-    'psi(2S)': {'tex': r"\psi(2S)\to", 'V': 'psi(2S)', 'Q': 2./3., }, 
-    'Upsilon(1S)': {'tex': r"\Upsilon(1S)\to", 'V': 'Upsilon(1S)', 'Q': -1./3., },
-    'Upsilon(2S)': {'tex': r"\Upsilon(2S)\to", 'V': 'Upsilon(2S)', 'Q': -1./3., },
-    'Upsilon(3S)': {'tex': r"\Upsilon(3S)\to", 'V': 'Upsilon(3S)', 'Q': -1./3., },
+    'psi(2S)': {'tex': r"\psi(2S)\to ", 'V': 'psi(2S)', 'Q': 2./3., }, 
+    'Upsilon(1S)': {'tex': r"\Upsilon(1S)\to ", 'V': 'Upsilon(1S)', 'Q': -1./3., },
+    'Upsilon(2S)': {'tex': r"\Upsilon(2S)\to ", 'V': 'Upsilon(2S)', 'Q': -1./3., },
+    'Upsilon(3S)': {'tex': r"\Upsilon(3S)\to ", 'V': 'Upsilon(3S)', 'Q': -1./3., },
  }
 
 _tex = {'ee': r'e^+e^-', 'mumu': r'\mu^+\mu^-', 'tautau': r'\tau^+\tau^-', 


### PR DESCRIPTION
I added spaces in the tex strings for the quarkonium decays after \to in order to correct the tex output for quarkonium decays with electrons like 
![image](https://github.com/user-attachments/assets/5e44e841-73c4-4a1c-acec-708f6e4e467f)
