### PR TITLE
Version -> 2.7.0, spring cleaning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           path: _src/
@@ -40,14 +40,11 @@ jobs:
           fi
           popd
 
-      - name: Build bdist
+      - name: Build sdist and wheel
         shell: bash
         run: |
-          mkdir dist
-          pushd _src
-          python3 ./setup.py sdist -d ../dist/
-          python3 ./setup.py bdist_wheel -d ../dist/
-          popd
+          pip install build
+          python3 -m build _src/ --outdir dist/
           
       - name: Test installing the wheel
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flavio"
-version = "2.6.2"
+version = "2.7.0"
 authors = [
     {name = "David M. Straub", email = "straub@protonmail.com"},
 ]
 description = "A Python package for flavour physics phenomenology in the Standard Model and beyond"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20.0",
     "scipy",
-    "setuptools",
     "pyyaml",
     "ckmutil>=1.2.0",
     "wilson>=2.5",


### PR DESCRIPTION
- Bump version to 2.7.0
- Bump min Python version to 3.10
- Update GH action versions
- Modernize CI build command
- Remove setuptools runtime dependency (this was only needed for pkg_resources which was removed in #276 