### PR TITLE
mu-e conversion in nuclei -  sign convention for covariant derivative

### DIFF
--- a/flavio/physics/mudecays/mueconversion.py
+++ b/flavio/physics/mudecays/mueconversion.py
@@ -23,12 +23,13 @@ def CR_mue(wc_obj, par, nucl):
     Vn  = par['Vn '+nucl]*mm**(5/2)
     omega_capt  = par['GammaCapture '+nucl]
     #####Wilson Coefficients######
-    #####Conversion Rate obtained from hep-ph/0203110#####
+    #####Conversion Rate obtained from hep-ph/0203110##### 
     flavio.citations.register("Kitano:2002mt")
     wc = wc_obj.get_wc('mue', scale, par, nf_out=3)
     prefac = -np.sqrt(2)/par['GF']
-    AL = prefac / ( 4 * mm ) * wc['Cgamma_emu']
-    AR = prefac / ( 4 * mm ) * wc['Cgamma_mue'].conjugate()
+    ### Note hep-ph/0203110 defines the covariant derivative as D = partial - i e Q A while flavio uses D= partial + i e Q A. This change in convention requires a minus sign when converting the dipole Wilson coefficients.
+    AL = - prefac / ( 4 * mm ) * wc['Cgamma_emu']
+    AR = - prefac / ( 4 * mm ) * wc['Cgamma_mue'].conjugate()
     gRV = {
         'u': prefac * ( wc['CVRR_mueuu'] + wc['CVLR_uumue'] ) / 2,
         'd': prefac * ( wc['CVRR_muedd'] + wc['CVLR_ddmue'] ) / 2,


### PR DESCRIPTION
Kitano et al [hep-ph/0203110](https://arxiv.org/abs/hep-ph/0203110) define the covariant derivative as D=partial - Q e A . See the paragraph below Eq. (1) on page 4.

This differs from the convention used in wilson/flavio otherwise.

Changing between the convention requires to also change the sign of the dipole operator which has been implemented by adding a minus sign to the definitions of AL and AR in the python code.