### PR TITLE
Update a_mu SM and exp

### DIFF
--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -8231,6 +8231,12 @@ FNAL g-2:
 FNAL g-2 combination:
   experiment: Muon g-2
   values:
+    a_mu: 116592061(41) e-11
+
+FNAL g-2 combination 2025:
+  experiment: Muon g-2
+  inspire: Muong-2:2025xyk
+  values:
     a_mu: 1165920715(145) e-12
 
 K+->pinunu E949 2009:

--- a/flavio/data/measurements.yml
+++ b/flavio/data/measurements.yml
@@ -8231,7 +8231,7 @@ FNAL g-2:
 FNAL g-2 combination:
   experiment: Muon g-2
   values:
-    a_mu: 116592061(41) e-11
+    a_mu: 1165920715(145) e-12
 
 K+->pinunu E949 2009:
   experiment: 'E949'

--- a/flavio/data/parameters_uncorrelated.yml
+++ b/flavio/data/parameters_uncorrelated.yml
@@ -450,8 +450,8 @@ delta_Gammab: 0 ± 0.21e-3
 delta_Gammanu: 0 ± 0.014e-3
 
 # anomalous magnetic moment of the muon
-# arXiv:2006.04822
-a_mu SM: 116591810(43) e-11
+# arXiv:2505.21476
+a_mu SM: 116592033(62) e-11
 
 # anomalous magnetic moment of the tau
 # arXiv:hep-ph/0701260 eq. (33)

--- a/flavio/physics/mdms/test_al.py
+++ b/flavio/physics/mdms/test_al.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 par = flavio.default_parameters.get_central_all()
-amu_SM = 116591810e-11
+amu_SM = 116592033e-11
 atau_SM = 117721e-8
 ae_SM = 0.00115965218157
 


### PR DESCRIPTION
This PR updates the SM prediction of `a_mu` to the one reported [here](https://inspirehep.net/literature/2925594) and the FNAL combination in measurements to the one reported [here](https://inspirehep.net/literature/2928642). The `FNAL g-2 combination` measurement is used in `smelli`.